### PR TITLE
Make sure to handle case where the digest is not set

### DIFF
--- a/src/couchdb3/database.py
+++ b/src/couchdb3/database.py
@@ -670,12 +670,14 @@ class Database(Base):
             f"{docid}/{attname}",
             query_kwargs={"rev": rev}
         )
+        content_md5 = response.headers.get("content-md5")
+        digest_value = f"md5-{content_md5}" if content_md5 else None
         return AttachmentDocument(
             content=response.content,
             content_encoding=response.headers.get("content-encoding"),
             content_length=response.headers.get("content-length"),
             content_type=response.headers.get("content-type"),
-            digest="md5-" + response.headers.get("content-md5"),
+            digest=digest_value,
         )
 
     def get_design(


### PR DESCRIPTION
The latest Couchdb removed the md5 digest from the get attachment api. 
The upstream change is: 

https://github.com/apache/couchdb/pull/4574/files

This Pull request allows digest to still be used, but if the couchdb server does not provide it, then the digest field is set to None. 

I have done some basic testing to check that the change works. 

