### PR TITLE
fix: include LICENSE file in sdist and wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "A wrapper around the CouchDB API."
 authors = [{ name = "Nikolai Vlahovic", email = "vlahovic.nikolai@gmail.com" }]
 requires-python = ">= 3.11"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
The `uv_build` backend only ships license files declared via project.license-files, which was absent from pyproject.toml, so the LICENSE was missing from published artifacts. Migrate the license declaration to PEP 639 SPDX form and add license-files.