### PR TITLE
Docs: add examples for fetching documents, views and Mango queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,63 @@ print(db.delete(docid=docid, rev=db.rev(docid)))  # Fetch the revision on the go
 # True
 ```
 
+### Fetching documents
+```python
+# Fetch a single document (returns None if not found)
+doc = db.get("mydoc-id")
+
+# Subscript shorthand (raises KeyError if not found)
+doc = db["mydoc-id"]
+
+# Fetch all documents (metadata only)
+result = db.all_docs()  # ViewResult
+
+# Fetch all documents with full bodies
+result = db.all_docs(include_docs=True)
+for row in result.rows:
+    print(row.id, row.doc)
+
+# Fetch specific documents by ID
+result = db.all_docs(keys=["id-1", "id-2"], include_docs=True)
+
+# Batch fetch by ID
+result = db.bulk_get(docs=[{"id": "id-1"}, {"id": "id-2"}])
+for item in result:
+    print(item["id"], item["docs"][0]["ok"])
+```
+
+### Views
+```python
+# 1. Create a design document with a map function
+db.put_design("my-ddoc", views={
+    "my-view": {
+        "map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"
+    }
+})
+
+# 2. Query the view
+result = db.view("my-ddoc", "my-view")                        # ViewResult
+result = db.view("my-ddoc", "my-view", include_docs=True, limit=10)
+
+# 3. Iterate results
+for row in result.rows:
+    print(row.id, row.key, row.value)
+```
+
+### Mango queries
+```python
+# 1. Create an index
+db.save_index({"fields": ["type", "name"]}, ddoc="my-ddoc", name="type-name-idx")
+
+# 2. Query with a selector
+result = db.find({"type": {"$eq": "post"}}, fields=["_id", "name"], limit=10)
+for doc in result["docs"]:
+    print(doc)
+
+# 3. Inspect the query plan
+plan = db.explain({"type": {"$eq": "post"}}, limit=10)
+```
+
 ### Working with partitions
 For a partitioned database, the `couchdb3.database.Partition` class offers a wrapper around partitions (acting similarly 
 to collections in Mongo). 

--- a/docs/database.html
+++ b/docs/database.html
@@ -152,6 +152,14 @@ el.replaceWith(d);
         Returns
         -------
         ViewResult
+
+        Examples
+        --------
+        &gt;&gt;&gt; db.all_docs()
+        &gt;&gt;&gt; db.all_docs(include_docs=True)
+        &gt;&gt;&gt; for row in db.all_docs(include_docs=True).rows:
+        ...     print(row.id, row.doc)
+        &gt;&gt;&gt; db.all_docs(keys=[&#34;id-1&#34;, &#34;id-2&#34;], include_docs=True)
         &#34;&#34;&#34;
         return self.view(
             f&#34;_partition/{partition}/_all_docs&#34; if partition else &#34;_all_docs&#34;,
@@ -219,6 +227,12 @@ el.replaceWith(d);
           - `docs` contains a single-item array of objects, each of which has either an `error` key and value describing
           the error, or `ok` key and associated value of the requested document, with the additional _revisions property
           that lists the parent revisions if `revs=true`.
+
+        Examples
+        --------
+        &gt;&gt;&gt; results = db.bulk_get(docs=[{&#34;id&#34;: &#34;id-1&#34;}, {&#34;id&#34;: &#34;id-2&#34;}])
+        &gt;&gt;&gt; for item in results:
+        ...     print(item[&#34;id&#34;], item[&#34;docs&#34;][0][&#34;ok&#34;])
         &#34;&#34;&#34;
         return (
             self._post(
@@ -524,6 +538,13 @@ el.replaceWith(d);
           - `bookmark`
           - `docs`
           - `warning`
+
+        Examples
+        --------
+        &gt;&gt;&gt; db.save_index({&#34;fields&#34;: [&#34;type&#34;, &#34;name&#34;]}, ddoc=&#34;my-ddoc&#34;, name=&#34;type-name-idx&#34;)
+        &gt;&gt;&gt; result = db.find({&#34;type&#34;: {&#34;$eq&#34;: &#34;post&#34;}}, fields=[&#34;_id&#34;, &#34;name&#34;], limit=10)
+        &gt;&gt;&gt; for doc in result[&#34;docs&#34;]:
+        ...     print(doc)
         &#34;&#34;&#34;
         return self._post(
             resource=partitioned_db_resource_parser(
@@ -624,6 +645,13 @@ el.replaceWith(d);
         Returns
         -------
         `couchdb3.document.Document`
+
+        Examples
+        --------
+        &gt;&gt;&gt; doc = db.get(&#34;mydoc-id&#34;)          # returns Document or None
+        &gt;&gt;&gt; doc = db[&#34;mydoc-id&#34;]              # subscript shorthand; raises KeyError if not found
+        &gt;&gt;&gt; doc = db.get(&#34;missing-id&#34;)        # returns None
+        &gt;&gt;&gt; doc = db.get(&#34;missing-id&#34;, check=True)  # raises CouchDBError if not found
         &#34;&#34;&#34;
         try:
             return Document(
@@ -827,6 +855,14 @@ el.replaceWith(d);
         Returns
         -------
         Tuple[str, bool, str] : The document&#39;s id ( `str`), the operation status (`bool`) and the revision ( `str`).
+
+        Examples
+        --------
+        &gt;&gt;&gt; db.put_design(&#34;my-ddoc&#34;, views={
+        ...     &#34;my-view&#34;: {
+        ...         &#34;map&#34;: &#34;function(doc) { if (doc.type === &#39;post&#39;) emit(doc._id, null); }&#34;
+        ...     }
+        ... })
         &#34;&#34;&#34;
         if partitioned:
             options = (options or dict()).update({&#34;partitioned&#34;: partitioned})
@@ -928,6 +964,14 @@ el.replaceWith(d);
           `&#34;exists&#34;`.
           - id (`str`) – Id of the design document the index was created in.
           - name (`str`) – Name of the index created.
+
+        Examples
+        --------
+        &gt;&gt;&gt; result, id, name = db.save_index(
+        ...     {&#34;fields&#34;: [&#34;type&#34;, &#34;name&#34;]},
+        ...     ddoc=&#34;my-ddoc&#34;,
+        ...     name=&#34;type-name-idx&#34;,
+        ... )
         &#34;&#34;&#34;
         data = self._post(
             resource=&#34;_index&#34;,
@@ -1094,6 +1138,9 @@ el.replaceWith(d);
                 }
             ]
         }
+        &gt;&gt;&gt; result = db.view(&#34;my-ddoc&#34;, &#34;my-view&#34;, include_docs=True, limit=10)
+        &gt;&gt;&gt; for row in result.rows:
+        ...     print(row.id, row.key, row.value, row.doc)
         &#34;&#34;&#34;
         path = partitioned_db_resource_parser(
             resource=&#34;_design&#34;,
@@ -1218,6 +1265,14 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
     Returns
     -------
     ViewResult
+
+    Examples
+    --------
+    &gt;&gt;&gt; db.all_docs()
+    &gt;&gt;&gt; db.all_docs(include_docs=True)
+    &gt;&gt;&gt; for row in db.all_docs(include_docs=True).rows:
+    ...     print(row.id, row.doc)
+    &gt;&gt;&gt; db.all_docs(keys=[&#34;id-1&#34;, &#34;id-2&#34;], include_docs=True)
     &#34;&#34;&#34;
     return self.view(
         f&#34;_partition/{partition}/_all_docs&#34; if partition else &#34;_all_docs&#34;,
@@ -1239,7 +1294,14 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <dl>
 <dt><code>ViewResult</code></dt>
 <dd>&nbsp;</dd>
-</dl></div>
+</dl>
+<h2 id="examples">Examples</h2>
+<pre><code class="language-python-repl">&gt;&gt;&gt; db.all_docs()
+&gt;&gt;&gt; db.all_docs(include_docs=True)
+&gt;&gt;&gt; for row in db.all_docs(include_docs=True).rows:
+...     print(row.id, row.doc)
+&gt;&gt;&gt; db.all_docs(keys=[&quot;id-1&quot;, &quot;id-2&quot;], include_docs=True)
+</code></pre></div>
 </dd>
 <dt id="couchdb3.database.Database.bulk_docs"><code class="name flex">
 <span>def <span class="ident">bulk_docs</span></span>(<span>self, docs: list[dict | Document], new_edits: bool = True) ‑> list[dict]</span>
@@ -1340,6 +1402,12 @@ document values.</p>
       - `docs` contains a single-item array of objects, each of which has either an `error` key and value describing
       the error, or `ok` key and associated value of the requested document, with the additional _revisions property
       that lists the parent revisions if `revs=true`.
+
+    Examples
+    --------
+    &gt;&gt;&gt; results = db.bulk_get(docs=[{&#34;id&#34;: &#34;id-1&#34;}, {&#34;id&#34;: &#34;id-2&#34;}])
+    &gt;&gt;&gt; for item in results:
+    ...     print(item[&#34;id&#34;], item[&#34;docs&#34;][0][&#34;ok&#34;])
     &#34;&#34;&#34;
     return (
         self._post(
@@ -1368,7 +1436,12 @@ document ID,</li>
 <li><code>docs</code> contains a single-item array of objects, each of which has either an <code>error</code> key and value describing
 the error, or <code>ok</code> key and associated value of the requested document, with the additional _revisions property
 that lists the parent revisions if <code>revs=true</code>.</li>
-</ul></div>
+</ul>
+<h2 id="examples">Examples</h2>
+<pre><code class="language-python-repl">&gt;&gt;&gt; results = db.bulk_get(docs=[{&quot;id&quot;: &quot;id-1&quot;}, {&quot;id&quot;: &quot;id-2&quot;}])
+&gt;&gt;&gt; for item in results:
+...     print(item[&quot;id&quot;], item[&quot;docs&quot;][0][&quot;ok&quot;])
+</code></pre></div>
 </dd>
 <dt id="couchdb3.database.Database.compact"><code class="name flex">
 <span>def <span class="ident">compact</span></span>(<span>self, ddoc: str | None = None) ‑> bool</span>
@@ -1842,6 +1915,13 @@ the query response. Default is <code>False</code>.</dd>
       - `bookmark`
       - `docs`
       - `warning`
+
+    Examples
+    --------
+    &gt;&gt;&gt; db.save_index({&#34;fields&#34;: [&#34;type&#34;, &#34;name&#34;]}, ddoc=&#34;my-ddoc&#34;, name=&#34;type-name-idx&#34;)
+    &gt;&gt;&gt; result = db.find({&#34;type&#34;: {&#34;$eq&#34;: &#34;post&#34;}}, fields=[&#34;_id&#34;, &#34;name&#34;], limit=10)
+    &gt;&gt;&gt; for doc in result[&#34;docs&#34;]:
+    ...     print(doc)
     &#34;&#34;&#34;
     return self._post(
         resource=partitioned_db_resource_parser(
@@ -1915,7 +1995,13 @@ the query response. Default is <code>False</code>.</dd>
 <li><code>bookmark</code></li>
 <li><code>docs</code></li>
 <li><code>warning</code></li>
-</ul></div>
+</ul>
+<h2 id="examples">Examples</h2>
+<pre><code class="language-python-repl">&gt;&gt;&gt; db.save_index({&quot;fields&quot;: [&quot;type&quot;, &quot;name&quot;]}, ddoc=&quot;my-ddoc&quot;, name=&quot;type-name-idx&quot;)
+&gt;&gt;&gt; result = db.find({&quot;type&quot;: {&quot;$eq&quot;: &quot;post&quot;}}, fields=[&quot;_id&quot;, &quot;name&quot;], limit=10)
+&gt;&gt;&gt; for doc in result[&quot;docs&quot;]:
+...     print(doc)
+</code></pre></div>
 </dd>
 <dt id="couchdb3.database.Database.get"><code class="name flex">
 <span>def <span class="ident">get</span></span>(<span>self,<br>docid: str,<br>*,<br>attachments: bool | None = None,<br>att_encoding_info: bool | None = None,<br>atts_since: Iterable[str] | None = None,<br>conflicts: bool | None = None,<br>deleted_conflicts: bool | None = None,<br>latest: bool | None = None,<br>local_seq: bool | None = None,<br>meta: bool | None = None,<br>open_revs: Iterable[str] | None = None,<br>rev: str | None = None,<br>revs: bool | None = None,<br>revs_info: bool | None = None,<br>check: bool | None = None,<br>default_value: Any | None = None) ‑> <a title="couchdb3.document.Document" href="document.html#couchdb3.document.Document">Document</a> | Any</span>
@@ -1986,6 +2072,13 @@ the query response. Default is <code>False</code>.</dd>
     Returns
     -------
     `couchdb3.document.Document`
+
+    Examples
+    --------
+    &gt;&gt;&gt; doc = db.get(&#34;mydoc-id&#34;)          # returns Document or None
+    &gt;&gt;&gt; doc = db[&#34;mydoc-id&#34;]              # subscript shorthand; raises KeyError if not found
+    &gt;&gt;&gt; doc = db.get(&#34;missing-id&#34;)        # returns None
+    &gt;&gt;&gt; doc = db.get(&#34;missing-id&#34;, check=True)  # raises CouchDBError if not found
     &#34;&#34;&#34;
     try:
         return Document(
@@ -2050,7 +2143,13 @@ revisions. Default <code>None</code>.</dd>
 <dd>The default value to return if <code>check=False</code> and the <code>docid</code> is not in the database. Default <code>None</code>.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
-<p><code><a title="couchdb3.document.Document" href="document.html#couchdb3.document.Document">Document</a></code></p></div>
+<p><code><a title="couchdb3.document.Document" href="document.html#couchdb3.document.Document">Document</a></code></p>
+<h2 id="examples">Examples</h2>
+<pre><code class="language-python-repl">&gt;&gt;&gt; doc = db.get(&quot;mydoc-id&quot;)          # returns Document or None
+&gt;&gt;&gt; doc = db[&quot;mydoc-id&quot;]              # subscript shorthand; raises KeyError if not found
+&gt;&gt;&gt; doc = db.get(&quot;missing-id&quot;)        # returns None
+&gt;&gt;&gt; doc = db.get(&quot;missing-id&quot;, check=True)  # raises CouchDBError if not found
+</code></pre></div>
 </dd>
 <dt id="couchdb3.database.Database.get_attachment"><code class="name flex">
 <span>def <span class="ident">get_attachment</span></span>(<span>self, docid: str, attname: str, rev: str | None = None) ‑> <a title="couchdb3.document.AttachmentDocument" href="document.html#couchdb3.document.AttachmentDocument">AttachmentDocument</a></span>
@@ -2403,6 +2502,14 @@ Must be provided when passing the <code>content</code> argument.</dd>
     Returns
     -------
     Tuple[str, bool, str] : The document&#39;s id ( `str`), the operation status (`bool`) and the revision ( `str`).
+
+    Examples
+    --------
+    &gt;&gt;&gt; db.put_design(&#34;my-ddoc&#34;, views={
+    ...     &#34;my-view&#34;: {
+    ...         &#34;map&#34;: &#34;function(doc) { if (doc.type === &#39;post&#39;) emit(doc._id, null); }&#34;
+    ...     }
+    ... })
     &#34;&#34;&#34;
     if partitioned:
         options = (options or dict()).update({&#34;partitioned&#34;: partitioned})
@@ -2453,7 +2560,14 @@ design document functions.</dd>
 </dl>
 <p>Further <code><a title="couchdb3.database.Database.save" href="#couchdb3.database.Database.save">Database.save()</a></code> parameters.</p>
 <h2 id="returns">Returns</h2>
-<p>Tuple[str, bool, str] : The document's id ( <code>str</code>), the operation status (<code>bool</code>) and the revision ( <code>str</code>).</p></div>
+<p>Tuple[str, bool, str] : The document's id ( <code>str</code>), the operation status (<code>bool</code>) and the revision ( <code>str</code>).</p>
+<h2 id="examples">Examples</h2>
+<pre><code class="language-python-repl">&gt;&gt;&gt; db.put_design(&quot;my-ddoc&quot;, views={
+...     &quot;my-view&quot;: {
+...         &quot;map&quot;: &quot;function(doc) { if (doc.type === 'post') emit(doc._id, null); }&quot;
+...     }
+... })
+</code></pre></div>
 </dd>
 <dt id="couchdb3.database.Database.save"><code class="name flex">
 <span>def <span class="ident">save</span></span>(<span>self,<br>doc: dict | Document,<br>batch: bool | None = None,<br>new_edits: bool | None = None,<br>path: str | None = None) ‑> tuple[str, bool, str]</span>
@@ -2570,6 +2684,14 @@ to the creation of conflicts.</dd>
       `&#34;exists&#34;`.
       - id (`str`) – Id of the design document the index was created in.
       - name (`str`) – Name of the index created.
+
+    Examples
+    --------
+    &gt;&gt;&gt; result, id, name = db.save_index(
+    ...     {&#34;fields&#34;: [&#34;type&#34;, &#34;name&#34;]},
+    ...     ddoc=&#34;my-ddoc&#34;,
+    ...     name=&#34;type-name-idx&#34;,
+    ... )
     &#34;&#34;&#34;
     data = self._post(
         resource=&#34;_index&#34;,
@@ -2613,7 +2735,14 @@ database, an error occurs.</dd>
 <code>"exists"</code>.</li>
 <li>id (<code>str</code>) – Id of the design document the index was created in.</li>
 <li>name (<code>str</code>) – Name of the index created.</li>
-</ul></div>
+</ul>
+<h2 id="examples">Examples</h2>
+<pre><code class="language-python-repl">&gt;&gt;&gt; result, id, name = db.save_index(
+...     {&quot;fields&quot;: [&quot;type&quot;, &quot;name&quot;]},
+...     ddoc=&quot;my-ddoc&quot;,
+...     name=&quot;type-name-idx&quot;,
+... )
+</code></pre></div>
 </dd>
 <dt id="couchdb3.database.Database.security"><code class="name flex">
 <span>def <span class="ident">security</span></span>(<span>self) ‑> <a title="couchdb3.document.SecurityDocument" href="document.html#couchdb3.document.SecurityDocument">SecurityDocument</a></span>
@@ -2808,6 +2937,9 @@ Operation status.</p></div>
             }
         ]
     }
+    &gt;&gt;&gt; result = db.view(&#34;my-ddoc&#34;, &#34;my-view&#34;, include_docs=True, limit=10)
+    &gt;&gt;&gt; for row in result.rows:
+    ...     print(row.id, row.key, row.value, row.doc)
     &#34;&#34;&#34;
     path = partitioned_db_resource_parser(
         resource=&#34;_design&#34;,
@@ -2927,6 +3059,9 @@ ViewResult: {
         }
     ]
 }
+&gt;&gt;&gt; result = db.view(&quot;my-ddoc&quot;, &quot;my-view&quot;, include_docs=True, limit=10)
+&gt;&gt;&gt; for row in result.rows:
+...     print(row.id, row.key, row.value, row.doc)
 </code></pre></div>
 </dd>
 </dl>

--- a/docs/index.html
+++ b/docs/index.html
@@ -130,6 +130,57 @@ print(db.save(mydoc))
 print(db.delete(docid=docid, rev=db.rev(docid)))  # Fetch the revision on the go
 # True
 </code></pre>
+<h3 id="fetching-documents">Fetching documents</h3>
+<pre><code class="language-python"># Fetch a single document (returns None if not found)
+doc = db.get(&quot;mydoc-id&quot;)
+
+# Subscript shorthand (raises KeyError if not found)
+doc = db[&quot;mydoc-id&quot;]
+
+# Fetch all documents (metadata only)
+result = db.all_docs()  # ViewResult
+
+# Fetch all documents with full bodies
+result = db.all_docs(include_docs=True)
+for row in result.rows:
+    print(row.id, row.doc)
+
+# Fetch specific documents by ID
+result = db.all_docs(keys=[&quot;id-1&quot;, &quot;id-2&quot;], include_docs=True)
+
+# Batch fetch by ID
+result = db.bulk_get(docs=[{&quot;id&quot;: &quot;id-1&quot;}, {&quot;id&quot;: &quot;id-2&quot;}])
+for item in result:
+    print(item[&quot;id&quot;], item[&quot;docs&quot;][0][&quot;ok&quot;])
+</code></pre>
+<h3 id="views">Views</h3>
+<pre><code class="language-python"># 1. Create a design document with a map function
+db.put_design(&quot;my-ddoc&quot;, views={
+    &quot;my-view&quot;: {
+        &quot;map&quot;: &quot;function(doc) { if (doc.type === 'post') emit(doc._id, null); }&quot;
+    }
+})
+
+# 2. Query the view
+result = db.view(&quot;my-ddoc&quot;, &quot;my-view&quot;)                        # ViewResult
+result = db.view(&quot;my-ddoc&quot;, &quot;my-view&quot;, include_docs=True, limit=10)
+
+# 3. Iterate results
+for row in result.rows:
+    print(row.id, row.key, row.value)
+</code></pre>
+<h3 id="mango-queries">Mango queries</h3>
+<pre><code class="language-python"># 1. Create an index
+db.save_index({&quot;fields&quot;: [&quot;type&quot;, &quot;name&quot;]}, ddoc=&quot;my-ddoc&quot;, name=&quot;type-name-idx&quot;)
+
+# 2. Query with a selector
+result = db.find({&quot;type&quot;: {&quot;$eq&quot;: &quot;post&quot;}}, fields=[&quot;_id&quot;, &quot;name&quot;], limit=10)
+for doc in result[&quot;docs&quot;]:
+    print(doc)
+
+# 3. Inspect the query plan
+plan = db.explain({&quot;type&quot;: {&quot;$eq&quot;: &quot;post&quot;}}, limit=10)
+</code></pre>
 <h3 id="working-with-partitions">Working with partitions</h3>
 <p>For a partitioned database, the <code><a title="couchdb3.database.Partition" href="database.html#couchdb3.database.Partition">Partition</a></code> class offers a wrapper around partitions (acting similarly
 to collections in Mongo). </p>
@@ -216,6 +267,9 @@ partition.save({
 <li><a href="#creating-a-document">Creating a document</a></li>
 <li><a href="#updating-a-document">Updating a document</a></li>
 <li><a href="#deleting-a-document">Deleting a document</a></li>
+<li><a href="#fetching-documents">Fetching documents</a></li>
+<li><a href="#views">Views</a></li>
+<li><a href="#mango-queries">Mango queries</a></li>
 <li><a href="#working-with-partitions">Working with partitions</a></li>
 </ul>
 </li>

--- a/src/couchdb3/__init__.py
+++ b/src/couchdb3/__init__.py
@@ -122,6 +122,63 @@ print(db.delete(docid=docid, rev=db.rev(docid)))  # Fetch the revision on the go
 # True
 ```
 
+### Fetching documents
+```python
+# Fetch a single document (returns None if not found)
+doc = db.get("mydoc-id")
+
+# Subscript shorthand (raises KeyError if not found)
+doc = db["mydoc-id"]
+
+# Fetch all documents (metadata only)
+result = db.all_docs()  # ViewResult
+
+# Fetch all documents with full bodies
+result = db.all_docs(include_docs=True)
+for row in result.rows:
+    print(row.id, row.doc)
+
+# Fetch specific documents by ID
+result = db.all_docs(keys=["id-1", "id-2"], include_docs=True)
+
+# Batch fetch by ID
+result = db.bulk_get(docs=[{"id": "id-1"}, {"id": "id-2"}])
+for item in result:
+    print(item["id"], item["docs"][0]["ok"])
+```
+
+### Views
+```python
+# 1. Create a design document with a map function
+db.put_design("my-ddoc", views={
+    "my-view": {
+        "map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"
+    }
+})
+
+# 2. Query the view
+result = db.view("my-ddoc", "my-view")                        # ViewResult
+result = db.view("my-ddoc", "my-view", include_docs=True, limit=10)
+
+# 3. Iterate results
+for row in result.rows:
+    print(row.id, row.key, row.value)
+```
+
+### Mango queries
+```python
+# 1. Create an index
+db.save_index({"fields": ["type", "name"]}, ddoc="my-ddoc", name="type-name-idx")
+
+# 2. Query with a selector
+result = db.find({"type": {"$eq": "post"}}, fields=["_id", "name"], limit=10)
+for doc in result["docs"]:
+    print(doc)
+
+# 3. Inspect the query plan
+plan = db.explain({"type": {"$eq": "post"}}, limit=10)
+```
+
 ### Working with partitions
 For a partitioned database, the `couchdb3.database.Partition` class offers a wrapper around partitions (acting similarly 
 to collections in Mongo). 

--- a/src/couchdb3/database.py
+++ b/src/couchdb3/database.py
@@ -127,6 +127,14 @@ class Database(Base):
         Returns
         -------
         ViewResult
+
+        Examples
+        --------
+        >>> db.all_docs()
+        >>> db.all_docs(include_docs=True)
+        >>> for row in db.all_docs(include_docs=True).rows:
+        ...     print(row.id, row.doc)
+        >>> db.all_docs(keys=["id-1", "id-2"], include_docs=True)
         """
         return self.view(
             f"_partition/{partition}/_all_docs" if partition else "_all_docs",
@@ -194,6 +202,12 @@ class Database(Base):
           - `docs` contains a single-item array of objects, each of which has either an `error` key and value describing
           the error, or `ok` key and associated value of the requested document, with the additional _revisions property
           that lists the parent revisions if `revs=true`.
+
+        Examples
+        --------
+        >>> results = db.bulk_get(docs=[{"id": "id-1"}, {"id": "id-2"}])
+        >>> for item in results:
+        ...     print(item["id"], item["docs"][0]["ok"])
         """
         return (
             self._post(
@@ -499,6 +513,13 @@ class Database(Base):
           - `bookmark`
           - `docs`
           - `warning`
+
+        Examples
+        --------
+        >>> db.save_index({"fields": ["type", "name"]}, ddoc="my-ddoc", name="type-name-idx")
+        >>> result = db.find({"type": {"$eq": "post"}}, fields=["_id", "name"], limit=10)
+        >>> for doc in result["docs"]:
+        ...     print(doc)
         """
         return self._post(
             resource=partitioned_db_resource_parser(
@@ -599,6 +620,13 @@ class Database(Base):
         Returns
         -------
         `couchdb3.document.Document`
+
+        Examples
+        --------
+        >>> doc = db.get("mydoc-id")          # returns Document or None
+        >>> doc = db["mydoc-id"]              # subscript shorthand; raises KeyError if not found
+        >>> doc = db.get("missing-id")        # returns None
+        >>> doc = db.get("missing-id", check=True)  # raises CouchDBError if not found
         """
         try:
             return Document(
@@ -802,6 +830,14 @@ class Database(Base):
         Returns
         -------
         Tuple[str, bool, str] : The document's id ( `str`), the operation status (`bool`) and the revision ( `str`).
+
+        Examples
+        --------
+        >>> db.put_design("my-ddoc", views={
+        ...     "my-view": {
+        ...         "map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"
+        ...     }
+        ... })
         """
         if partitioned:
             options = (options or dict()).update({"partitioned": partitioned})
@@ -903,6 +939,14 @@ class Database(Base):
           `"exists"`.
           - id (`str`) – Id of the design document the index was created in.
           - name (`str`) – Name of the index created.
+
+        Examples
+        --------
+        >>> result, id, name = db.save_index(
+        ...     {"fields": ["type", "name"]},
+        ...     ddoc="my-ddoc",
+        ...     name="type-name-idx",
+        ... )
         """
         data = self._post(
             resource="_index",
@@ -1069,6 +1113,9 @@ class Database(Base):
                 }
             ]
         }
+        >>> result = db.view("my-ddoc", "my-view", include_docs=True, limit=10)
+        >>> for row in result.rows:
+        ...     print(row.id, row.key, row.value, row.doc)
         """
         path = partitioned_db_resource_parser(
             resource="_design",


### PR DESCRIPTION
Addresses #11.

## Changes

- **README.md** + **`src/couchdb3/__init__.py`**: three new Quickstart sections
  - *Fetching documents*: `db.get`, `db[]` shorthand, `db.all_docs` (with `include_docs` and `keys`), `db.bulk_get`
  - *Views*: `db.put_design` → `db.view` → iterate `ViewResult.rows`
  - *Mango queries*: `db.save_index` → `db.find` → `db.explain`

- **`src/couchdb3/database.py`**: `Examples` sections added to seven methods:
  `all_docs`, `bulk_get`, `find`, `get`, `put_design`, `save_index`, `view`

- **`docs/`**: regenerated HTML via `make html`

Closes #11