### PR TITLE
Docs: Cleanup and update refactor agent

### DIFF
--- a/.opencode/agents/refactor.md
+++ b/.opencode/agents/refactor.md
@@ -1,68 +1,52 @@
 ---
-description: Deep-context agent for couchdb3 refactoring work. Use for planning or implementing changes to the HTTP layer, async client, or core base classes. Has full knowledge of the two-phase refactor plan and the httpx migration that was completed in Step 1.
+description: Deep-context agent for couchdb3 development. Has full knowledge of the project's sync/async architecture, the httpx migration, and the aio subpackage structure.
 mode: all
 permission:
   edit: ask
 ---
 
-You are a specialist agent for the `couchdb3` library refactoring project.
+You are a specialist agent for the `couchdb3` library.
 
 ## Project context
 
-`couchdb3` is a synchronous Python wrapper around the CouchDB 3.x HTTP API (Python >= 3.11).
+`couchdb3` is a sync and async Python wrapper around the CouchDB 3.x HTTP API (Python >= 3.11).
 
 **Class hierarchy:**
-- `Base` (`base.py`) — HTTP dispatcher, session management, auth, cookie token refresh
-- `Server(Base)` (`server.py`) — server-level ops: `all_dbs`, `create`, `delete`, `replicate`, `up`
-- `Database(Base)` (`database.py`) — document/view/index ops: `get`, `save`, `find`, `view`, `bulk_docs`, etc.
-- `Partition(Database)` (`database.py`) — thin wrapper that prepends `_partition/{id}/` to all requests
+- `Base` (`sync/base.py`) — Sync HTTP dispatcher.
+- `AsyncBase` (`aio/async_base.py`) — Async HTTP dispatcher.
+- `Server` (`sync/server.py`) / `AsyncServer` (`aio/async_server.py`) — Server-level operations.
+- `Database` (`sync/database.py`) / `AsyncDatabase` (`aio/async_database.py`) — Doc/view/index operations.
+- `Partition` (`sync/database.py`) / `AsyncPartition` (`aio/async_database.py`) — Partitioned database wrappers.
 
-**Single shared `httpx.Client`:** `Server` creates one `httpx.Client`. When it returns a `Database`
-via `Server.get()`, it passes `session=self.session`. `Database` sets `_owns_session = False` and
-never closes the client. Only the owner closes it in `__del__`/`__exit__`.
+**Shared components:**
+`document.py`, `exceptions.py`, `utils.py`, `view.py` are shared and agnostic to sync/async.
+
+**Single shared client:** Each `(Async)Server` creates one `httpx.(Async)Client`. Children receive the session and set `_owns_session = False` to avoid premature closure. Only the parent closes the client in `__del__`/`__exit__` (sync) or `aclose()` (async).
 
 **Request flow:**
-```
-Public method → Base._get/_post/_put/_delete/_head → Base._request → httpx.Client.request
-                                                                    → utils.check_response
-                                                                      (maps HTTP codes → CouchDBError subclasses)
-```
+Sync: `Public method → Base._request → httpx.Client.request`
+Async: `Public method → AsyncBase._request → httpx.AsyncClient.request`
+Shared: `utils.check_response` (maps HTTP codes → `CouchDBError` subclasses).
 
-## What has been done (Step 1 — complete)
+## What has been done (v3.2.0)
 
-- Replaced `requests` with `httpx` across all source and test files
-- Replaced `urllib3` with stdlib `urllib.parse`
-- `build_url()` now returns `str` (was `urllib3.util.Url`)
-- `httpx.Client(verify=, headers=)` set at construction (not mutable post-init like requests.Session)
-- `_owns_session` flag prevents child objects from closing a shared client
-- `cookies.jar` used in `_is_auth_token_expired` (httpx iterates cookies as strings, not objects)
-- `put_attachment` uses `content=` not `data=` (httpx deprecation)
-- `disable_ssl_verification` stored on `Base` (replaces `session.verify` read)
-- `pyproject.toml` and `setup.py` updated: `requests` → `httpx>=0.27,<1.0`
-- All 42 tests pass
-
-## What is planned (Step 2 — not yet started)
-
-Async client using `httpx.AsyncClient`, exposed as `AsyncServer`, `AsyncDatabase`, `AsyncPartition`.
-- New files: `async_base.py`, `async_server.py`, `async_database.py`
-- Same `_owns_session` ownership pattern
-- `__aenter__`/`__aexit__`/`aclose()` instead of `__enter__`/`__exit__`/`close()`
-- Exported from `__init__.py` alongside sync classes
-- `utils.py` requires no changes (no sync/async coupling)
+1. **requests → httpx migration** (Step 1, PR #32)
+2. **Restructuring into `sync/` and `aio/`** subpackages (Step 2, PR #34)
+3. **Async client implementation** using `httpx.AsyncClient` (Step 2, PR #34)
+4. **All 78 tests passing** (42 sync + 36 async)
 
 ## Key conventions
 
 - numpydoc docstrings
-- `from __future__ import annotations` + `from typing import ...` for all type hints
+- `from __future__ import annotations` + `from typing import ...` (where needed)
 - `__all__` defined in every public module
-- Tests use `uv run python3 -m unittest discover -s tests -t tests` (`make test`)
-- CouchDB credentials in `.env`: `COUCHDB_USER`, `COUCHDB_PASSWORD`, `COUCHDB0_URL`
-- Docker CouchDB runs on `127.0.0.1:59840`
+- Modern generics (`list[str]`, `dict | None`, etc.) — ruff-enforced
+- Tests: `unittest.IsolatedAsyncioTestCase` for async; `make test` (sync+async)
 
 ## Your behaviour
 
-- Always read the relevant source files before proposing changes
-- Prefer minimal, surgical edits — this is a library with a stable public API
-- When implementing Step 2, mirror the sync class structure exactly; do not change public method signatures
-- Ask before writing to files (permission: edit: ask)
+- Always read relevant source files before proposing changes
+- Prefer minimal, surgical edits
+- Ask before writing (permission: edit: ask)
 - Run `make test` to verify changes before declaring them complete
+

--- a/.opencode/skills/couchdb3-async/SKILL.md
+++ b/.opencode/skills/couchdb3-async/SKILL.md
@@ -1,13 +1,8 @@
----
-name: couchdb3-async
-description: Use when implementing or modifying the async couchdb3 client: AsyncServer, AsyncDatabase, AsyncPartition, async_base.py, async_server.py, async_database.py. Covers the full design, asyncio.Lock auth renewal, _owns_session ownership pattern, and test strategy using IsolatedAsyncioTestCase.
----
-
 # couchdb3 Async Client — Implementation Reference
 
 ## Status
 Step 1 (requests → httpx) is **complete and merged** (PR #32, v3.1.0).
-Step 2 (async client) is **in progress**.
+Step 2 (async client) is **complete and merged** (PR #34, v3.2.0).
 
 ---
 
@@ -34,12 +29,12 @@ await client.aclose()
 
 ```
 src/couchdb3/
-├── base.py              ← sync (unchanged)
-├── server.py            ← sync (unchanged)
-├── database.py          ← sync (unchanged)
-├── async_base.py        ← AsyncBase
-├── async_server.py      ← AsyncServer(AsyncBase)
-└── async_database.py    ← AsyncDatabase(AsyncBase), AsyncPartition(AsyncDatabase)
+├── sync/                ← Base, Server, Database, Partition
+├── aio/                 ← AsyncBase, AsyncServer, AsyncDatabase, AsyncPartition
+├── document.py          ← shared (DictBase, Document, etc.)
+├── exceptions.py        ← shared
+├── utils.py             ← shared
+└── view.py              ← shared
 ```
 
 `utils.py`, `exceptions.py`, `document.py`, `view.py` — **shared, unchanged**.
@@ -50,19 +45,19 @@ src/couchdb3/
 ## Class hierarchy
 
 ```
-AsyncBase (async_base.py)
-├── AsyncServer (async_server.py)
-└── AsyncDatabase (async_database.py)
-    └── AsyncPartition (async_database.py)
+AsyncBase (aio/async_base.py)
+├── AsyncServer (aio/async_server.py)
+└── AsyncDatabase (aio/async_database.py)
+    └── AsyncPartition (aio/async_database.py)
 ```
 
-Mirrors the sync hierarchy exactly (Option A — parallel trees, no shared base class between sync and async).
+Mirrors the sync hierarchy exactly.
 
 ---
 
 ## AsyncBase
 
-### Key differences from Base
+### Key differences from sync Base
 
 | Sync (`Base`) | Async (`AsyncBase`) |
 |---|---|
@@ -79,68 +74,19 @@ Mirrors the sync hierarchy exactly (Option A — parallel trees, no shared base 
 Identical signature to `Base.__init__`. Additions:
 - `httpx.AsyncClient` instead of `httpx.Client`
 - `self._auth_lock = asyncio.Lock()` for cookie token renewal
-- `self.disable_ssl_verification` stored (same as sync — no `session.verify` attribute on httpx clients)
-- `_owns_session` flag (identical pattern to sync)
+- `self.disable_ssl_verification` stored
+- `_owns_session` flag
 
 ```python
 import asyncio
 import httpx
 
-if session is not None:
-    self.session = session
-    self._owns_session = False
-else:
-    self.session = httpx.AsyncClient(
-        verify=disable_ssl_verification is False,
-        headers={"Accept": "application/json", "Content-type": "application/json"},
-    )
-    self._owns_session = True
+# ... in __init__ ...
+self.session = httpx.AsyncClient(...)
 self._auth_lock = asyncio.Lock()
 ```
 
-### Lifecycle — no `__del__`
-
-`__del__` is not implemented — `await` is not valid inside it.
-Users must use `async with` or call `await obj.aclose()` explicitly.
-
-```python
-async def __aenter__(self):
-    return self
-
-async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-    await self.aclose()
-
-async def aclose(self) -> None:
-    if self._owns_session:
-        await self.session.aclose()
-```
-
-### `_owns_session` — identical to sync
-
-Child objects (`AsyncDatabase`, `AsyncPartition`) receive a session from their
-parent (`AsyncServer.get()`, `AsyncDatabase.get_partition()`) and set
-`_owns_session = False`. They never call `aclose()`.
-
-Only the object that created the `httpx.AsyncClient` owns and closes it.
-
-### Cookie auth — double-checked locking with `asyncio.Lock`
-
-`_is_auth_token_expired()` stays **synchronous** — it only reads a timestamp, no I/O:
-
-```python
-def _is_auth_token_expired(self) -> bool:
-    try:
-        return (
-            next(
-                _.expires
-                for _ in self.session.cookies.jar
-                if _.name == "AuthSession"
-            )
-            <= datetime.now(timezone.utc).timestamp()
-        )
-    except StopIteration:
-        return True
-```
+### Cookie auth — double-checked locking
 
 `_renew_auth_token()` is **async**, guarded by double-checked locking:
 
@@ -148,100 +94,34 @@ def _is_auth_token_expired(self) -> bool:
 async def _renew_auth_token(self) -> None:
     async with self._auth_lock:
         # Re-check inside the lock: another coroutine may have renewed already
-        # while this one was waiting to acquire the lock.
         if self._is_auth_token_expired():
-            await self._post(
-                resource="_session",
-                body={"name": self._user, "password": self._password},
-                auth_method="basic",
-                root="",
-            )
-```
-
-In `_request`, the outer check avoids acquiring the lock on every call (happy path has zero contention).
-The inner check inside the lock handles the race window.
-
-`asyncio.Lock` coordinates coroutines within the same event loop only — consistent
-with `httpx.AsyncClient`'s own contract (not thread-safe by design).
-
-### `_request` dispatcher
-
-```python
-async def _request(self, *, method, resource=None, body=None,
-                   query_kwargs=None, auth_method=None, root=None,
-                   timeout=None, **req_kwargs) -> httpx.Response:
-    auth_method = auth_method or self.auth_method
-    root = root if isinstance(root, str) else self.root
-    path = ""
-    if root:
-        path += root
-    if body and isinstance(body, dict):
-        for k in utils.COUCH_DB_RESERVED_DOC_FIELDS:
-            if k in body and body.get(k) is None:
-                del body[k]
-    if resource:
-        path += f"/{resource}"
-    if auth_method == "basic":
-        req_kwargs.update({"auth": self._auth})
-    elif auth_method == "cookie":
-        if self._is_auth_token_expired():
-            await self._renew_auth_token()
-    response = await self.session.request(
-        method=method,
-        url=utils.build_url(
-            scheme=self.scheme,
-            host=self.host,
-            path=path,
-            port=self.port,
-            **(query_kwargs or {}),
-        ),
-        json=body,
-        timeout=timeout or self.timeout,
-        **req_kwargs,
-    )
-    utils.check_response(response=response)
-    return response
+            await self._post(...)
 ```
 
 ---
 
-## AsyncServer
+## AsyncServer / AsyncDatabase / AsyncPartition
 
-Mirrors `Server` exactly. All public methods are `async def`.
+Mirror their sync counterparts exactly. All public methods are `async def`.
 
 ### `__getitem__` — not supported
-Python does not allow `__getitem__` to be a coroutine.
 `db = client["mydb"]` is **not available** on async classes.
 Use `db = await client.get("mydb")` instead.
-
-### `get()` returns `AsyncDatabase`
-
-Passes `session=self.session` to `AsyncDatabase` — child sets `_owns_session=False`.
-
----
-
-## AsyncDatabase / AsyncPartition
-
-Mirrors `Database` and `Partition` exactly. All public methods are `async def`.
-
-`get_partition()` returns `AsyncPartition`.
-
-`__getitem__` — not supported (same as `AsyncServer`). Use `await db.get(docid)`.
 
 ---
 
 ## `__init__.py` exports
 
 ```python
-from .async_server import AsyncServer as AsyncServer
-from .async_database import AsyncDatabase as AsyncDatabase, AsyncPartition as AsyncPartition
+from .aio import AsyncServer as AsyncServer
+from .aio import AsyncDatabase as AsyncDatabase, AsyncPartition as AsyncPartition
 ```
 
 ---
 
 ## Testing
 
-Use `unittest.IsolatedAsyncioTestCase` (stdlib, Python ≥ 3.8 — zero new dependencies):
+Use `unittest.IsolatedAsyncioTestCase`:
 
 ```python
 import unittest
@@ -259,19 +139,5 @@ tests/
 ├── test_async_server.py
 └── test_async_database.py
 ```
+`make test` picks up `IsolatedAsyncioTestCase` automatically.
 
-Mirror `test_server.py` and `test_database.py` respectively.
-Credentials from `.env` via `tests/credentials.py` (unchanged).
-`make test` picks up `IsolatedAsyncioTestCase` automatically via `unittest discover`.
-
----
-
-## Implementation checklist
-
-- [ ] `src/couchdb3/async_base.py` — `AsyncBase`
-- [ ] `src/couchdb3/async_server.py` — `AsyncServer`
-- [ ] `src/couchdb3/async_database.py` — `AsyncDatabase`, `AsyncPartition`
-- [ ] `src/couchdb3/__init__.py` — export async classes
-- [ ] `tests/test_async_server.py`
-- [ ] `tests/test_async_database.py`
-- [ ] `make test` — all tests pass (sync + async)

--- a/.opencode/skills/couchdb3-refactor/SKILL.md
+++ b/.opencode/skills/couchdb3-refactor/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: couchdb3-refactor
-description: Use when working on the couchdb3 HTTP layer, sync client, or core base classes: base.py, server.py, database.py, utils.py. Documents the completed requests→httpx migration (Step 1, merged PR #32, v3.1.0). For the async client implementation see the couchdb3-async skill.
+description: Use when working on the couchdb3 HTTP layer, sync client, or core base classes (sync/base.py, sync/server.py, sync/database.py, utils.py). Documents the completed requests→httpx migration and library restructuring (v3.2.0). For the async client implementation see the couchdb3-async skill.
 ---
 
 # couchdb3 Refactor Reference
 
 ## Project Overview
 
-`couchdb3` is a synchronous Python wrapper around the CouchDB 3.x HTTP API.
+`couchdb3` is a sync and async Python wrapper around the CouchDB 3.x HTTP API.
 
-**Class hierarchy:**
+**Sync Class hierarchy:**
 ```
-Base (base.py)
-├── Server (server.py)       — server-level operations (all_dbs, create, delete, replicate, up)
-└── Database (database.py)   — document/view/index operations
-    └── Partition (database.py) — partitioned-database wrapper, delegates to Database
+Base (sync/base.py)
+├── Server (sync/server.py)       — server-level operations (all_dbs, create, delete, replicate, up)
+└── Database (sync/database.py)   — document/view/index operations
+    └── Partition (sync/database.py) — partitioned-database wrapper, delegates to Database
 ```
 
-**Request flow:**
+**Request flow (sync):**
 ```
 Server/Database method
   → Base._get/_post/_put/_delete/_head
@@ -32,9 +32,9 @@ Only the owning object (the one that created the `httpx.Client`) closes it in `_
 
 ---
 
-## Step 1 — requests → httpx (COMPLETE — PR #32, v3.1.0)
+## Migration History (v3.2.0 complete)
 
-### Symbol mapping
+### Symbol mapping (requests → httpx)
 
 | `requests` | `httpx` | Notes |
 |---|---|---|
@@ -44,47 +44,15 @@ Only the owning object (the one that created the `httpx.Client`) closes it in `_
 | `session.headers.update(h)` | `httpx.Client(headers=h)` | **headers are constructor-only in httpx** |
 | `session.request(method, url, json=, timeout=)` | `client.request(...)` | identical signature |
 | `session.cookies` (iterates strings) | `client.cookies.jar` (iterates `http.cookiejar.Cookie`) | **must use `.jar` for `.name`/`.expires`** |
-| `response.raise_for_status()` | `response.raise_for_status()` | raises `httpx.HTTPStatusError`, not `requests.exceptions.HTTPError` |
+| `response.raise_for_status()` | `response.raise_for_status()` | raises `httpx.HTTPStatusError` |
 | `response.json()/.content/.headers/.status_code/.text` | identical | |
 | `requests.exceptions.ConnectionError` | `httpx.ConnectError` | |
 | `requests.exceptions.HTTPError` | `httpx.HTTPStatusError` | |
 | `requests.exceptions.RequestException` | `httpx.RequestError` | broad base class |
-| `requests.Response` (type hint) | `httpx.Response` | |
-| `requests.get(url, timeout=)` | `httpx.get(url, timeout=)` | top-level convenience fn |
-
-### Files changed
-
-| File | What changed |
-|---|---|
-| `src/couchdb3/utils.py` | `requests`→`httpx`; `urllib3`→stdlib `urlparse`; `build_url` returns `str`; `check_response` catches `httpx` exceptions |
-| `src/couchdb3/base.py` | `requests.Session`→`httpx.Client`; `HTTPBasicAuth`→`httpx.BasicAuth`; `verify`/`headers` at Client constructor; `_owns_session` flag; `cookies.jar` for token expiry |
-| `src/couchdb3/server.py` | type hints updated; `httpx.RequestError`; reads `self.disable_ssl_verification` |
-| `src/couchdb3/database.py` | same as server.py; `content=` instead of `data=` in `put_attachment` |
-| `tests/credentials.py` | `httpx.get`; `httpx.ConnectError` |
-| `tests/test_utils.py` | removed `.url` call — `build_url` now returns `str` |
-| `pyproject.toml` | `requests` → `httpx>=0.27,<1.0`; dev tools moved to `[project.optional-dependencies] dev` |
-| `setup.py` | `install_requires` → `["httpx>=0.27,<1.0"]` |
-| `scripts/build.sh`, `deploy.sh`, `deploy-test.sh` | removed `uv add` calls; safe `dist` folder check; `uv run python3 -m build/twine` |
-
-### Key behavioural differences
-
-1. **`verify` is immutable post-construction in httpx.** `Base.__init__` stores
-   `self.disable_ssl_verification` so child objects can read it without touching
-   `session.verify` (which does not exist on `httpx.Client`).
-
-2. **`httpx.Client.cookies` iterates `(name, value)` string pairs**, not cookie objects.
-   Use `client.cookies.jar` to get `http.cookiejar.Cookie` objects with `.name`/`.expires`.
-   This is done in `Base._is_auth_token_expired`.
-
-3. **Session ownership.** `httpx.Client` raises `RuntimeError` if used after `.close()`.
-   The `_owns_session` flag on `Base` ensures only the creating object closes the client.
-
-4. **`put_attachment` uses `content=` not `data=`.** httpx 0.27+ deprecates `data=`
-   for raw bytes.
 
 ---
 
-## Step 2 — Async client
+## Async client (v3.2.0 complete)
 
 See `.opencode/skills/couchdb3-async/SKILL.md` for the full async implementation reference.
 
@@ -94,7 +62,7 @@ See `.opencode/skills/couchdb3-async/SKILL.md` for the full async implementation
 
 ```bash
 make test
-# Requires: COUCHDB_USER, COUCHDB_PASSWORD, COUCHDB0_URL in .env or environment
+# Requires: COUCHDB_USER, COUCHDB_PASSWORD, COUCHDB0_URL in .env
 # Docker CouchDB must be running
 
 # Run a single test file:
@@ -102,7 +70,12 @@ uv run python3 -m unittest tests.test_server
 ```
 
 **Test isolation note:** `tests/test_server.py` uses hardcoded `TEST_DB_NAME = "test-db"`.
-If a prior run crashed before cleanup, delete it manually before re-running.
+If a prior run crashed before cleanup, delete it manually:
+```python
+from couchdb3 import Server
+s = Server("http://...:...") # credentials
+if "test-db" in s: s.delete("test-db")
+```
 
 ---
 


### PR DESCRIPTION
Updates the refactor agent in .opencode/ to reflect the new architecture (sync/aio subpackages, httpx/async completion, updated test counts and conventions).