### PR TITLE
Chore: Ruff linting/formatting, dependency cleanup, bump to v3.2.1

### DIFF
--- a/.opencode/skills/couchdb3-async/SKILL.md
+++ b/.opencode/skills/couchdb3-async/SKILL.md
@@ -127,6 +127,7 @@ Use `unittest.IsolatedAsyncioTestCase`:
 import unittest
 from couchdb3 import AsyncServer
 
+
 class TestAsyncServer(unittest.IsolatedAsyncioTestCase):
     async def test_up(self):
         async with AsyncServer("http://user:pass@127.0.0.1:59840") as client:

--- a/.opencode/skills/couchdb3-refactor/SKILL.md
+++ b/.opencode/skills/couchdb3-refactor/SKILL.md
@@ -73,8 +73,10 @@ uv run python3 -m unittest tests.test_server
 If a prior run crashed before cleanup, delete it manually:
 ```python
 from couchdb3 import Server
-s = Server("http://...:...") # credentials
-if "test-db" in s: s.delete("test-db")
+
+s = Server("http://...:...")  # credentials
+if "test-db" in s:
+    s.delete("test-db")
 ```
 
 ---

--- a/.opencode/skills/couchdb3-version-bump/SKILL.md
+++ b/.opencode/skills/couchdb3-version-bump/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: couchdb3-version-bump
+description: Use when bumping the couchdb3 version. Lists every file to update, the correct command to sync uv.lock, and the semantic versioning rules for choosing a, b, or c in a.b.c.
+---
+
+# couchdb3 Version Bump
+
+## Files to update
+
+| File | What to change |
+|---|---|
+| `pyproject.toml` | `version = "x.y.z"` under `[project]` |
+| `setup.py` | `version="x.y.z"` |
+| `uv.lock` | **Do not edit manually** — run `uv sync` after updating the above two files |
+
+## SOP
+
+1. Decide the new version (see rules below)
+2. Update `pyproject.toml` → `version = "x.y.z"`
+3. Update `setup.py` → `version="x.y.z"`
+4. Run `uv sync` to regenerate `uv.lock`
+5. Run `make test` to verify nothing is broken
+6. Commit all three files: `git commit -m "Bump version to x.y.z"`
+
+## Semantic versioning rules (`a.b.c`)
+
+`couchdb3` follows [Semantic Versioning](https://semver.org). The library is in the `3.x.x` family
+(the `3` reflects CouchDB 3.x compatibility, not a breaking API change).
+
+### `c` — patch (e.g. `3.2.0` → `3.2.1`)
+- Bug fixes with no public API changes
+- Linting, formatting, or style-only changes shipped as a release
+- Dependency pin adjustments
+- Internal refactors with no user-visible behaviour change
+
+### `b` — minor (e.g. `3.2.0` → `3.3.0`)
+- New functionality added in a backward-compatible way
+- New public methods, classes, or parameters with defaults
+- New submodules or re-export paths that don't remove existing ones
+- Examples: async client added (`3.1.0` → `3.2.0`)
+
+### `a` — major (e.g. `3.2.0` → `4.0.0`)
+- Breaking changes to the public API
+- Removing or renaming existing public classes, methods, or parameters
+- Changing method signatures in a non-backward-compatible way
+- Dropping Python version support
+
+## Version history
+
+| Version | PR | Change |
+|---|---|---|
+| `3.0.4` | — | Original baseline |
+| `3.1.0` | #32 | `requests` → `httpx` migration |
+| `3.2.0` | #34 | Async client, `sync/` and `aio/` subpackages |
+| `3.2.1` | #36 | Linting/style fixes, ruff config, dependency cleanup |

--- a/contributing.md
+++ b/contributing.md
@@ -16,22 +16,33 @@ Firstly, a rough explanation of the file structure is provided below.
 
 To get started, clone the project into a directory of your choice - say `~/couchdb3`.
 
-Next, you'll need an (virtual) environment: I like to use `venv` but `pipenv` or other alternatives work just as well.
+### Setting up with uv (recommended)
 
-### A Few Notes on venv
-Creating a new virtual environment can be done with the command
+The project uses [uv](https://docs.astral.sh/uv/) for environment and dependency management.
+To get started:
+
 ```bash
-python3 -m venv /path/to/venv
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone and enter the project
+git clone https://github.com/n-Vlahovic/couchdb3
+cd couchdb3
+
+# Create the environment, install the package and all dev dependencies
+uv sync
+uv pip install -e ".[dev]"
 ```
-which creates the env at the designated location (relative to your current path).
-Activating the env can be done via the command
-```bash
-source /path/to/venv/bin/activate
-```
-and deactivating simply with
-```bash
-deactivate
-```
+
+From there, prefix commands with `uv run` to run them inside the managed environment, e.g.
+`uv run python3`, `uv run ruff check .`, etc. — or use `make test`, `make build` etc. which
+handle this automatically.
+
+### Other environments
+
+`venv`, `pipenv`, `conda` and similar tools work fine too. The only requirement is that
+`httpx>=0.27,<1.0` is available at runtime, and the dev extras (`build`, `pdoc3`, `ruff`,
+`setuptools`, `twine`) are available when running the corresponding `make` targets.
 
 ## Requirements
 

--- a/contributing.md
+++ b/contributing.md
@@ -61,9 +61,12 @@ Backwards compatibility might be a future topic but as of now `v3` is the only o
 ### Python Packages
 The package itself only requires `httpx` (c.f. `setup.py` and `pyproject.toml`).
 
-Dev/build tools (`build`, `pdoc3`, `setuptools`, `twine`) are declared under
-`[project.optional-dependencies] dev` in `pyproject.toml` and are installed by certain `make`
-commands automatically (e.g. `make build` uses `build`, `make html` uses `pdoc3`).
+Dev/build tools (`build`, `pdoc3`, `ruff`, `setuptools`, `twine`) are declared under
+`[project.optional-dependencies] dev` in `pyproject.toml`. Install them all in one step:
+
+```bash
+uv pip install -e ".[dev]"
+```
 
 
 ## Testing

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-Hello, happy that you're reading this as this projects highly welcomes new contributors.
+Hello, happy that you're reading this as this project highly welcomes new contributors.
 
 Below, you'll find a few notes on how to
 
@@ -16,10 +16,10 @@ Firstly, a rough explanation of the file structure is provided below.
 
 To get started, clone the project into a directory of your choice - say `~/couchdb3`.
 
-Next, you'll need an (virtual) environment: I like to use `venv` but `pipenv`or other alternatives work just as well.
+Next, you'll need an (virtual) environment: I like to use `venv` but `pipenv` or other alternatives work just as well.
 
 ### A Few Notes on venv
-Creating a new virtual environment can be done with the command 
+Creating a new virtual environment can be done with the command
 ```bash
 python3 -m venv /path/to/venv
 ```
@@ -39,7 +39,7 @@ deactivate
 
 - Python `>=3.11`
 - CouchDB `3.x.x`
-- Python packages `requests setuptools>=42 wheel`
+- Python package `httpx>=0.27,<1.0`
 
 ### Python Interpreter
 A Python version `>=3.11` is required as prior versions reached EoL.
@@ -51,7 +51,7 @@ for annotation purposes.
 
 ### CouchDB Version
 In order to be able to truly test the package, you'll want to have a running CouchDB server.
-Of course, it doesn't need to be a server running on your local machine, even though this is the simpler approach when 
+Of course, it doesn't need to be a server running on your local machine, even though this is the simpler approach when
 testing and debugging.
 
 So far, I only ever used CouchDB `v 3.x.x` but neither `v 2.x.x` nor `v 1.x.x`.
@@ -59,13 +59,11 @@ Backwards compatibility might be a future topic but as of now `v3` is the only o
 
 
 ### Python Packages
-Next, you'll want to install the requirements:
-The package itself only requires `requests` (c.f `setup.py`).
-However, you'll want to install the packages `setuptools>=42` and `wheel` for packaging purposes.
-In addition, other packages will be installed when invoking certain `make` commands.
-For example `make build ` installs the package `build`,
-`make deploy-test` installs `twine`
-and `make html` installs `pdoc3`.
+The package itself only requires `httpx` (c.f. `setup.py` and `pyproject.toml`).
+
+Dev/build tools (`build`, `pdoc3`, `setuptools`, `twine`) are declared under
+`[project.optional-dependencies] dev` in `pyproject.toml` and are installed by certain `make`
+commands automatically (e.g. `make build` uses `build`, `make html` uses `pdoc3`).
 
 
 ## Testing
@@ -73,20 +71,20 @@ and `make html` installs `pdoc3`.
 
 ### CouchDB Server Setup
 
-There are many ways to get started with CouchDB: you can check out 
-[their download section](http://couchdb.apache.org/#download), 
+There are many ways to get started with CouchDB: you can check out
+[their download section](http://couchdb.apache.org/#download),
 [their official docker image](https://hub.docker.com/_/couchdb),
 check out cloud service providers or also your package manager.
 
-I created a small [CouchDB Docker Setup](https://github.com/n-vlahovic/couchdb-docker-setup) 
+I created a small [CouchDB Docker Setup](https://github.com/n-vlahovic/couchdb-docker-setup)
 which sets up CouchDB locally using Docker. It was designed to run two standalone servers in order to test replication.
 
-To use this setup, clone the repository and execute the build command 
-(c.f. [README.md](https://github.com/n-vlahovic/couchdb-docker-setup/blob/master/README.md) ).
+To use this setup, clone the repository and execute the build command
+(c.f. [README.md](https://github.com/n-vlahovic/couchdb-docker-setup/blob/master/README.md)).
 
 ### Unit Tests
 
-The folder `tests` contains several unittests which require a working connection to a server. 
+The folder `tests` contains several unittests which require a working connection to a server.
 The file `tests/credentials.py` handles the credentials by searching for the following environment variables:
 - `COUCHDB_USER`
 - `COUCHDB_PASSWORD`
@@ -98,111 +96,129 @@ Each variable is searched for as follows:
 3. Prompt the user for input
 
 The variable `COUCHDB_URL` has one additional step:
-0. Check if the default local CouchDB URL (`http://localhost:5984`) points to a running server (by sending a `GET` 
+0. Check if the default local CouchDB URL (`http://localhost:5984`) points to a running server (by sending a `GET`
 request).
 
 To run all tests, one can execute the command
-```bash 
+```bash
 make test
 ```
-which executes `python -m unittest discover -s tests -t tests`.
+which executes `uv run python3 -m unittest discover -s tests -t tests`.
 
 
 ## Submitting changes
-To submit changes, simply create a new branch following the format 
-`username/<optional_date-><description>` 
-where `<description>` denotes a short description of the new branch 
+To submit changes, simply create a new branch following the format
+`username/<optional_date-><description>`
+where `<description>` denotes a short description of the new branch
 (e.g. `n-vlahovic/2022-09-get_attachment_bug_fix`).
 Then, push your updates into that branch and open a new pull request for review.
 
 ## Coding conventions
 The code style is fairly straightforward:
-Use annotations whenever possible, ideally using the builtin module 
-[typing](https://docs.python.org/3/library/typing.html).
+use annotations whenever possible, using modern built-in generics (`dict`, `list`, `tuple`, `set`)
+rather than the deprecated `typing` equivalents (`Dict`, `List`, `Tuple`, `Set`).
 
-Further, the docstrings type used is [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html).
+Docstrings follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) format.
 
-Here is a simple example
+Here is a simple example:
 ```python
-from typing import Dict, List, Optional, Tuple
+from __future__ import annotations
 
 
-CONST: List[int] = [1, 2, 3]
+CONST: list[int] = [1, 2, 3]
 """CONST is a list of integers"""
 
 
-def foo(
-    data: Dict
-) -> Tuple[Optional[str], str]:
+def foo(data: dict) -> tuple[str | None, str]:
     """
     My function foo.
-    
+
     Parameters
     ----------
-    data : Dict
+    data : dict
         A simple dictionary which must contain the key `name`.
-    
+
     Returns
     -------
-    Tuple[Optional[str], str] : A tuple consisting of 
-    
+    tuple[str | None, str] : A tuple consisting of
+
     - the id
     - the name
     """
     return data.get("_id"), data["name"]
-
 ```
+
+## Linting & formatting
+
+The project uses [ruff](https://docs.astral.sh/ruff/) for both linting and formatting.
+Configuration lives in `pyproject.toml` under `[tool.ruff]`.
+
+To check for issues:
+```bash
+uv run ruff check .
+```
+
+To auto-fix all fixable issues:
+```bash
+uv run ruff check . --fix
+```
+
+To format:
+```bash
+uv run ruff format .
+```
+
+Please ensure `uv run ruff check .` reports no errors before submitting a pull request.
 
 ## File structure
 ```
-├── archive  # .gitignore (created automatically when building)
+├── archive              # .gitignore (created automatically when building)
 ├── contributing.md
-├── dist  # .gitignore (created automatically when building)
-├── docs  # Automatically created when running "make html"
-│   ├── base.html
-│   ├── database.html
-│   ├── document.html
-│   ├── exceptions.html
-│   ├── index.html
-│   ├── server.html
-│   ├── utils.html
-│   └── view.html
+├── dist                 # .gitignore (created automatically when building)
+├── docs                 # Automatically created when running "make html"
 ├── LICENSE
 ├── Makefile
 ├── pyproject.toml
 ├── README.md
-├── scripts  # Scripts called in Makefile
-│   ├── build.sh
-│   ├── deploy.sh
-│   ├── deploy-test.sh
-│   ├── html.sh
-│   └── test.sh
+├── scripts              # Scripts called in Makefile
+│   ├── build.sh
+│   ├── deploy.sh
+│   ├── deploy-test.sh
+│   ├── html.sh
+│   └── test.sh
 ├── setup.py
 ├── src
-│   ├── couchdb3  # Module location
-│   │   ├── base.py
-│   │   ├── database.py
-│   │   ├── document.py
-│   │   ├── exceptions.py
-│   │   ├── __init__.py
-│   │   ├── server.py
-│   │   ├── utils.py
-│   │   └── view.py
-│   └── __init__.py
+│   ├── couchdb3         # Module location
+│   │   ├── aio/         # Async client subpackage
+│   │   │   ├── __init__.py
+│   │   │   ├── async_base.py
+│   │   │   ├── async_database.py
+│   │   │   └── async_server.py
+│   │   ├── sync/        # Sync client subpackage
+│   │   │   ├── __init__.py
+│   │   │   ├── base.py
+│   │   │   ├── database.py
+│   │   │   └── server.py
+│   │   ├── __init__.py  # Flat re-exports (backward compatible)
+│   │   ├── document.py  # Shared types (Document, DictBase, etc.)
+│   │   ├── exceptions.py
+│   │   ├── utils.py
+│   │   └── view.py
+│   └── __init__.py
 └── tests
     ├── attachments
-    │   ├── test.html
-    │   ├── test.json
-    │   ├── test.png
-    │   └── test.txt
+    │   ├── test.html
+    │   ├── test.json
+    │   ├── test.png
+    │   └── test.txt
     ├── credentials.py
     ├── __init__.py
+    ├── test_async_database.py
+    ├── test_async_server.py
     ├── test_database.py
     ├── test_partitioned_database.py
     ├── test_server.py
     ├── test_utils.py
     └── views
         └── document-view.js
-
 ```
-

--- a/docs/aio/async_base.html
+++ b/docs/aio/async_base.html
@@ -208,11 +208,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         try:
             return (
-                next(
-                    _.expires
-                    for _ in self.session.cookies.jar
-                    if _.name == &#34;AuthSession&#34;
-                )
+                next(_.expires for _ in self.session.cookies.jar if _.name == &#34;AuthSession&#34;)
                 &lt;= datetime.now(UTC).timestamp()
             )
         except StopIteration:
@@ -561,9 +557,7 @@ el.replaceWith(d);
         -------
         dict: A dictionary containing the server&#39;s or database&#39;s info.
         &#34;&#34;&#34;
-        return (
-            await self._get(resource=f&#34;_partition/{partition}&#34; if partition else None)
-        ).json()
+        return (await self._get(resource=f&#34;_partition/{partition}&#34; if partition else None)).json()
 
     async def rev(self, resource: str) -&gt; str | None:
         &#34;&#34;&#34;
@@ -749,9 +743,7 @@ def url(self) -&gt; str:
     -------
     dict: A dictionary containing the server&#39;s or database&#39;s info.
     &#34;&#34;&#34;
-    return (
-        await self._get(resource=f&#34;_partition/{partition}&#34; if partition else None)
-    ).json()</code></pre>
+    return (await self._get(resource=f&#34;_partition/{partition}&#34; if partition else None)).json()</code></pre>
 </details>
 <div class="desc"><p>Return a server's or database's info by sending a <code>GET</code> request to <code>/self.root</code>.</p>
 <h2 id="parameters">Parameters</h2>

--- a/docs/aio/async_database.html
+++ b/docs/aio/async_database.html
@@ -184,9 +184,7 @@ el.replaceWith(d);
         list[dict] : Each item contains `id`, `ok`, and `rev`.
         &#34;&#34;&#34;
         return (
-            await self._post(
-                resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-            )
+            await self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits})
         ).json()
 
     async def bulk_get(
@@ -297,15 +295,11 @@ el.replaceWith(d);
         tuple[str, bool, str] : (id, ok, rev)
         &#34;&#34;&#34;
         data = (
-            await self._post(
-                body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-            )
+            await self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None})
         ).json()
         return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]
 
-    async def delete(
-        self, docid: str, rev: str, *, batch: bool | None = None
-    ) -&gt; bool:
+    async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
         &#34;&#34;&#34;
         Delete a document.
 
@@ -596,9 +590,9 @@ el.replaceWith(d);
                     )
                 ).json()
             )
-        except (CouchDBError, httpx.RequestError) as error:
+        except (CouchDBError, httpx.RequestError):
             if check:
-                raise error
+                raise
             return default_value
 
     async def get_attachment(
@@ -703,9 +697,7 @@ el.replaceWith(d);
                 &#39;Precisely one of the arguments &#34;content&#34; and &#34;path&#34; must be provided.&#39;
             )
         if content and not content_type:
-            raise ValueError(
-                &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-            )
+            raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
         resource = f&#34;{docid}/{attname}&#34;
         query_kwargs = {&#34;rev&#34;: rev}
         content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -901,9 +893,7 @@ el.replaceWith(d);
         bool : Operation status.
         &#34;&#34;&#34;
         return (
-            await self._put(
-                resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-            )
+            await self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members})
         ).json()[&#34;ok&#34;]
 
     async def view(
@@ -1179,9 +1169,7 @@ Default is <code>None</code>.</dd>
     list[dict] : Each item contains `id`, `ok`, and `rev`.
     &#34;&#34;&#34;
     return (
-        await self._post(
-            resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-        )
+        await self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits})
     ).json()</code></pre>
 </details>
 <div class="desc"><p>Create or update multiple documents in a single request.</p>
@@ -1376,9 +1364,7 @@ Default is <code>None</code>.</dd>
     tuple[str, bool, str] : (id, ok, rev)
     &#34;&#34;&#34;
     data = (
-        await self._post(
-            body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-        )
+        await self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None})
     ).json()
     return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]</code></pre>
 </details>
@@ -1404,9 +1390,7 @@ Default is <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def delete(
-    self, docid: str, rev: str, *, batch: bool | None = None
-) -&gt; bool:
+<pre><code class="python">async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
     &#34;&#34;&#34;
     Delete a document.
 
@@ -1815,9 +1799,9 @@ Default is <code>None</code>.</dd>
                 )
             ).json()
         )
-    except (CouchDBError, httpx.RequestError) as error:
+    except (CouchDBError, httpx.RequestError):
         if check:
-            raise error
+            raise
         return default_value</code></pre>
 </details>
 <div class="desc"><p>Get a document by id.</p>
@@ -2104,9 +2088,7 @@ Default <code>None</code>.</dd>
             &#39;Precisely one of the arguments &#34;content&#34; and &#34;path&#34; must be provided.&#39;
         )
     if content and not content_type:
-        raise ValueError(
-            &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-        )
+        raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
     resource = f&#34;{docid}/{attname}&#34;
     query_kwargs = {&#34;rev&#34;: rev}
     content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -2441,9 +2423,7 @@ Default <code>None</code>.</dd>
     bool : Operation status.
     &#34;&#34;&#34;
     return (
-        await self._put(
-            resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-        )
+        await self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members})
     ).json()[&#34;ok&#34;]</code></pre>
 </details>
 <div class="desc"><p>Update database security.</p>
@@ -2729,9 +2709,7 @@ Default <code>None</code>.</dd>
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
 
-    async def all_docs(
-        self, keys: Iterable[str] | None = None, **kwargs
-    ) -&gt; ViewResult:
+    async def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
         &#34;&#34;&#34;
         Executes the built-in _all_docs view, returning all documents in the partition.
 
@@ -2746,9 +2724,7 @@ Default <code>None</code>.</dd>
         -------
         ViewResult
         &#34;&#34;&#34;
-        return await super().all_docs(
-            partition=self.partition_id, keys=keys, **kwargs
-        )
+        return await super().all_docs(partition=self.partition_id, keys=keys, **kwargs)
 
     async def info(self) -&gt; dict:
         &#34;&#34;&#34;
@@ -2851,18 +2827,14 @@ Default <code>None</code>.</dd>
             update_seq=update_seq,
         )
 
-    async def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -&gt; list[dict]:
+    async def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;See `AsyncDatabase.bulk_docs`. Prepends partition ID to document IDs.&#34;&#34;&#34;
         return await super().bulk_docs(
             docs=[self.add_partition_to_doc(doc) for doc in docs],
             new_edits=new_edits,
         )
 
-    async def bulk_get(
-        self, docs: list[dict | Document], revs: bool = False
-    ) -&gt; list[dict]:
+    async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
         &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
         return await super().bulk_get(
             docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -2893,9 +2865,7 @@ Default <code>None</code>.</dd>
             batch=batch,
         )
 
-    async def delete(
-        self, docid: str, rev: str, *, batch: bool | None = None
-    ) -&gt; bool:
+    async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
         &#34;&#34;&#34;See `AsyncDatabase.delete`. Prepends partition ID to document ID.&#34;&#34;&#34;
         return await super().delete(
             docid=self.add_partition_to_str(docid),
@@ -3088,9 +3058,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def all_docs(
-    self, keys: Iterable[str] | None = None, **kwargs
-) -&gt; ViewResult:
+<pre><code class="python">async def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
     &#34;&#34;&#34;
     Executes the built-in _all_docs view, returning all documents in the partition.
 
@@ -3105,9 +3073,7 @@ Default <code>None</code>.</dd>
     -------
     ViewResult
     &#34;&#34;&#34;
-    return await super().all_docs(
-        partition=self.partition_id, keys=keys, **kwargs
-    )</code></pre>
+    return await super().all_docs(partition=self.partition_id, keys=keys, **kwargs)</code></pre>
 </details>
 <div class="desc"><p>Executes the built-in _all_docs view, returning all documents in the partition.</p>
 <h2 id="parameters">Parameters</h2>
@@ -3131,9 +3097,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def bulk_docs(
-    self, docs: list[dict | Document], new_edits: bool = True
-) -&gt; list[dict]:
+<pre><code class="python">async def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
     &#34;&#34;&#34;See `AsyncDatabase.bulk_docs`. Prepends partition ID to document IDs.&#34;&#34;&#34;
     return await super().bulk_docs(
         docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -3150,9 +3114,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def bulk_get(
-    self, docs: list[dict | Document], revs: bool = False
-) -&gt; list[dict]:
+<pre><code class="python">async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
     &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
     return await super().bulk_get(
         docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -3213,9 +3175,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def delete(
-    self, docid: str, rev: str, *, batch: bool | None = None
-) -&gt; bool:
+<pre><code class="python">async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
     &#34;&#34;&#34;See `AsyncDatabase.delete`. Prepends partition ID to document ID.&#34;&#34;&#34;
     return await super().delete(
         docid=self.add_partition_to_str(docid),

--- a/docs/aio/async_server.html
+++ b/docs/aio/async_server.html
@@ -298,9 +298,7 @@ el.replaceWith(d);
         -------
         AsyncDatabase
         &#34;&#34;&#34;
-        await self._put(
-            resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-        )
+        await self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
         return await self.get(name=name)
 
     async def dbs_info(self, keys: list[str]) -&gt; list[dict]:
@@ -344,11 +342,11 @@ el.replaceWith(d);
         )
         try:
             await db._head()
-        except (NotFoundError, httpx.RequestError) as error:
+        except (NotFoundError, httpx.RequestError):
             if check is True:
-                raise error
-        except CouchDBError as error:
-            raise error
+                raise
+        except CouchDBError:
+            raise
         return db
 
     async def delete(self, resource: str | None = None) -&gt; bool:
@@ -463,9 +461,9 @@ el.replaceWith(d);
         try:
             response = await self._get(resource=&#34;_up&#34;)
             return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-        except Exception as error:
+        except Exception:
             if raise_exception:
-                raise error
+                raise
             return False</code></pre>
 </details>
 <div class="desc"><p>Async CouchDB server client. Mirrors <code>Server</code> with <code>async def</code> methods throughout.</p>
@@ -673,9 +671,7 @@ instance and performing a <code>check</code> request.</p>
     -------
     AsyncDatabase
     &#34;&#34;&#34;
-    await self._put(
-        resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-    )
+    await self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
     return await self.get(name=name)</code></pre>
 </details>
 <div class="desc"><p>Create a database.</p>
@@ -798,11 +794,11 @@ instance and performing a <code>check</code> request.</p>
     )
     try:
         await db._head()
-    except (NotFoundError, httpx.RequestError) as error:
+    except (NotFoundError, httpx.RequestError):
         if check is True:
-            raise error
-    except CouchDBError as error:
-        raise error
+            raise
+    except CouchDBError:
+        raise
     return db</code></pre>
 </details>
 <div class="desc"><p>Get a database by name.</p>
@@ -1077,9 +1073,9 @@ instance and performing a <code>check</code> request.</p>
     try:
         response = await self._get(resource=&#34;_up&#34;)
         return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-    except Exception as error:
+    except Exception:
         if raise_exception:
-            raise error
+            raise
         return False</code></pre>
 </details>
 <div class="desc"><p>Check if the server is up.</p>

--- a/docs/aio/index.html
+++ b/docs/aio/index.html
@@ -204,9 +204,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         list[dict] : Each item contains `id`, `ok`, and `rev`.
         &#34;&#34;&#34;
         return (
-            await self._post(
-                resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-            )
+            await self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits})
         ).json()
 
     async def bulk_get(
@@ -317,15 +315,11 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         tuple[str, bool, str] : (id, ok, rev)
         &#34;&#34;&#34;
         data = (
-            await self._post(
-                body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-            )
+            await self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None})
         ).json()
         return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]
 
-    async def delete(
-        self, docid: str, rev: str, *, batch: bool | None = None
-    ) -&gt; bool:
+    async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
         &#34;&#34;&#34;
         Delete a document.
 
@@ -616,9 +610,9 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
                     )
                 ).json()
             )
-        except (CouchDBError, httpx.RequestError) as error:
+        except (CouchDBError, httpx.RequestError):
             if check:
-                raise error
+                raise
             return default_value
 
     async def get_attachment(
@@ -723,9 +717,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
                 &#39;Precisely one of the arguments &#34;content&#34; and &#34;path&#34; must be provided.&#39;
             )
         if content and not content_type:
-            raise ValueError(
-                &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-            )
+            raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
         resource = f&#34;{docid}/{attname}&#34;
         query_kwargs = {&#34;rev&#34;: rev}
         content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -921,9 +913,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         bool : Operation status.
         &#34;&#34;&#34;
         return (
-            await self._put(
-                resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-            )
+            await self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members})
         ).json()[&#34;ok&#34;]
 
     async def view(
@@ -1199,9 +1189,7 @@ Default is <code>None</code>.</dd>
     list[dict] : Each item contains `id`, `ok`, and `rev`.
     &#34;&#34;&#34;
     return (
-        await self._post(
-            resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-        )
+        await self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits})
     ).json()</code></pre>
 </details>
 <div class="desc"><p>Create or update multiple documents in a single request.</p>
@@ -1396,9 +1384,7 @@ Default is <code>None</code>.</dd>
     tuple[str, bool, str] : (id, ok, rev)
     &#34;&#34;&#34;
     data = (
-        await self._post(
-            body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-        )
+        await self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None})
     ).json()
     return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]</code></pre>
 </details>
@@ -1424,9 +1410,7 @@ Default is <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def delete(
-    self, docid: str, rev: str, *, batch: bool | None = None
-) -&gt; bool:
+<pre><code class="python">async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
     &#34;&#34;&#34;
     Delete a document.
 
@@ -1835,9 +1819,9 @@ Default is <code>None</code>.</dd>
                 )
             ).json()
         )
-    except (CouchDBError, httpx.RequestError) as error:
+    except (CouchDBError, httpx.RequestError):
         if check:
-            raise error
+            raise
         return default_value</code></pre>
 </details>
 <div class="desc"><p>Get a document by id.</p>
@@ -2124,9 +2108,7 @@ Default <code>None</code>.</dd>
             &#39;Precisely one of the arguments &#34;content&#34; and &#34;path&#34; must be provided.&#39;
         )
     if content and not content_type:
-        raise ValueError(
-            &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-        )
+        raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
     resource = f&#34;{docid}/{attname}&#34;
     query_kwargs = {&#34;rev&#34;: rev}
     content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -2461,9 +2443,7 @@ Default <code>None</code>.</dd>
     bool : Operation status.
     &#34;&#34;&#34;
     return (
-        await self._put(
-            resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-        )
+        await self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members})
     ).json()[&#34;ok&#34;]</code></pre>
 </details>
 <div class="desc"><p>Update database security.</p>
@@ -2749,9 +2729,7 @@ Default <code>None</code>.</dd>
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
 
-    async def all_docs(
-        self, keys: Iterable[str] | None = None, **kwargs
-    ) -&gt; ViewResult:
+    async def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
         &#34;&#34;&#34;
         Executes the built-in _all_docs view, returning all documents in the partition.
 
@@ -2766,9 +2744,7 @@ Default <code>None</code>.</dd>
         -------
         ViewResult
         &#34;&#34;&#34;
-        return await super().all_docs(
-            partition=self.partition_id, keys=keys, **kwargs
-        )
+        return await super().all_docs(partition=self.partition_id, keys=keys, **kwargs)
 
     async def info(self) -&gt; dict:
         &#34;&#34;&#34;
@@ -2871,18 +2847,14 @@ Default <code>None</code>.</dd>
             update_seq=update_seq,
         )
 
-    async def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -&gt; list[dict]:
+    async def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;See `AsyncDatabase.bulk_docs`. Prepends partition ID to document IDs.&#34;&#34;&#34;
         return await super().bulk_docs(
             docs=[self.add_partition_to_doc(doc) for doc in docs],
             new_edits=new_edits,
         )
 
-    async def bulk_get(
-        self, docs: list[dict | Document], revs: bool = False
-    ) -&gt; list[dict]:
+    async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
         &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
         return await super().bulk_get(
             docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -2913,9 +2885,7 @@ Default <code>None</code>.</dd>
             batch=batch,
         )
 
-    async def delete(
-        self, docid: str, rev: str, *, batch: bool | None = None
-    ) -&gt; bool:
+    async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
         &#34;&#34;&#34;See `AsyncDatabase.delete`. Prepends partition ID to document ID.&#34;&#34;&#34;
         return await super().delete(
             docid=self.add_partition_to_str(docid),
@@ -3108,9 +3078,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def all_docs(
-    self, keys: Iterable[str] | None = None, **kwargs
-) -&gt; ViewResult:
+<pre><code class="python">async def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
     &#34;&#34;&#34;
     Executes the built-in _all_docs view, returning all documents in the partition.
 
@@ -3125,9 +3093,7 @@ Default <code>None</code>.</dd>
     -------
     ViewResult
     &#34;&#34;&#34;
-    return await super().all_docs(
-        partition=self.partition_id, keys=keys, **kwargs
-    )</code></pre>
+    return await super().all_docs(partition=self.partition_id, keys=keys, **kwargs)</code></pre>
 </details>
 <div class="desc"><p>Executes the built-in _all_docs view, returning all documents in the partition.</p>
 <h2 id="parameters">Parameters</h2>
@@ -3151,9 +3117,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def bulk_docs(
-    self, docs: list[dict | Document], new_edits: bool = True
-) -&gt; list[dict]:
+<pre><code class="python">async def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
     &#34;&#34;&#34;See `AsyncDatabase.bulk_docs`. Prepends partition ID to document IDs.&#34;&#34;&#34;
     return await super().bulk_docs(
         docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -3170,9 +3134,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def bulk_get(
-    self, docs: list[dict | Document], revs: bool = False
-) -&gt; list[dict]:
+<pre><code class="python">async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
     &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
     return await super().bulk_get(
         docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -3233,9 +3195,7 @@ Default <code>None</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">async def delete(
-    self, docid: str, rev: str, *, batch: bool | None = None
-) -&gt; bool:
+<pre><code class="python">async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
     &#34;&#34;&#34;See `AsyncDatabase.delete`. Prepends partition ID to document ID.&#34;&#34;&#34;
     return await super().delete(
         docid=self.add_partition_to_str(docid),
@@ -3813,9 +3773,7 @@ Default <code>None</code>.</dd>
         -------
         AsyncDatabase
         &#34;&#34;&#34;
-        await self._put(
-            resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-        )
+        await self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
         return await self.get(name=name)
 
     async def dbs_info(self, keys: list[str]) -&gt; list[dict]:
@@ -3859,11 +3817,11 @@ Default <code>None</code>.</dd>
         )
         try:
             await db._head()
-        except (NotFoundError, httpx.RequestError) as error:
+        except (NotFoundError, httpx.RequestError):
             if check is True:
-                raise error
-        except CouchDBError as error:
-            raise error
+                raise
+        except CouchDBError:
+            raise
         return db
 
     async def delete(self, resource: str | None = None) -&gt; bool:
@@ -3978,9 +3936,9 @@ Default <code>None</code>.</dd>
         try:
             response = await self._get(resource=&#34;_up&#34;)
             return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-        except Exception as error:
+        except Exception:
             if raise_exception:
-                raise error
+                raise
             return False</code></pre>
 </details>
 <div class="desc"><p>Async CouchDB server client. Mirrors <code>Server</code> with <code>async def</code> methods throughout.</p>
@@ -4188,9 +4146,7 @@ instance and performing a <code>check</code> request.</p>
     -------
     AsyncDatabase
     &#34;&#34;&#34;
-    await self._put(
-        resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-    )
+    await self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
     return await self.get(name=name)</code></pre>
 </details>
 <div class="desc"><p>Create a database.</p>
@@ -4313,11 +4269,11 @@ instance and performing a <code>check</code> request.</p>
     )
     try:
         await db._head()
-    except (NotFoundError, httpx.RequestError) as error:
+    except (NotFoundError, httpx.RequestError):
         if check is True:
-            raise error
-    except CouchDBError as error:
-        raise error
+            raise
+    except CouchDBError:
+        raise
     return db</code></pre>
 </details>
 <div class="desc"><p>Get a database by name.</p>
@@ -4592,9 +4548,9 @@ instance and performing a <code>check</code> request.</p>
     try:
         response = await self._get(resource=&#34;_up&#34;)
         return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-    except Exception as error:
+    except Exception:
         if raise_exception:
-            raise error
+            raise
         return False</code></pre>
 </details>
 <div class="desc"><p>Check if the server is up.</p>

--- a/docs/sync/base.html
+++ b/docs/sync/base.html
@@ -124,9 +124,7 @@ el.replaceWith(d);
             self._owns_session = True
         self._user = user
         self._password = password
-        self._auth = (
-            httpx.BasicAuth(user, password) if user and password else None
-        )
+        self._auth = httpx.BasicAuth(user, password) if user and password else None
         self.auth_method = auth_method
         self.timeout = timeout
 
@@ -519,11 +517,7 @@ el.replaceWith(d);
             # httpx.Client.cookies.jar yields http.cookiejar.Cookie objects which
             # carry the .name and .expires attributes we need.
             return (
-                next(
-                    _.expires
-                    for _ in self.session.cookies.jar
-                    if _.name == &#34;AuthSession&#34;
-                )
+                next(_.expires for _ in self.session.cookies.jar if _.name == &#34;AuthSession&#34;)
                 &lt;= datetime.now(UTC).timestamp()
             )
         except StopIteration:
@@ -575,9 +569,7 @@ el.replaceWith(d);
         -------
         Dict: A dictionary containing the server&#39;s or database&#39;s info.
         &#34;&#34;&#34;
-        return self._get(
-            resource=f&#34;_partition/{partition}&#34; if partition else None
-        ).json()
+        return self._get(resource=f&#34;_partition/{partition}&#34; if partition else None).json()
 
     def rev(self, resource: str) -&gt; str | None:
         &#34;&#34;&#34;
@@ -730,9 +722,7 @@ def url(self) -&gt; str:
     -------
     Dict: A dictionary containing the server&#39;s or database&#39;s info.
     &#34;&#34;&#34;
-    return self._get(
-        resource=f&#34;_partition/{partition}&#34; if partition else None
-    ).json()</code></pre>
+    return self._get(resource=f&#34;_partition/{partition}&#34; if partition else None).json()</code></pre>
 </details>
 <div class="desc"><p>Return a server's or database's info by sending a <code>GET</code> request to <code>/self.root</code>.</p>
 <h2 id="parameters">Parameters</h2>

--- a/docs/sync/database.html
+++ b/docs/sync/database.html
@@ -167,9 +167,7 @@ el.replaceWith(d);
             **kwargs,
         )
 
-    def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -&gt; list[dict]:
+    def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;
         The bulk document API allows you to create and update multiple documents at the same time within a single
         request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -198,9 +196,7 @@ el.replaceWith(d);
           - `ok` operation status
           - `rev` the document&#39;s revision
         &#34;&#34;&#34;
-        return self._post(
-            resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-        ).json()
+        return self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}).json()
 
     def bulk_get(
         self,
@@ -306,9 +302,7 @@ el.replaceWith(d);
         ).json()
         return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]
 
-    def create(
-        self, doc: dict | Document, *, batch: bool | None = None
-    ) -&gt; tuple[str, bool, str]:
+    def create(self, doc: dict | Document, *, batch: bool | None = None) -&gt; tuple[str, bool, str]:
         &#34;&#34;&#34;
         Create a new document.
 
@@ -323,9 +317,7 @@ el.replaceWith(d);
         -------
         Tuple[str, bool, str] : A tuple consisting of the id, success message &amp; revision.
         &#34;&#34;&#34;
-        data = self._post(
-            body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-        ).json()
+        data = self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}).json()
         return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]
 
     def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
@@ -351,9 +343,7 @@ el.replaceWith(d);
         )
         return True
 
-    def delete_attachment(
-        self, docid: str, attname: str, rev: str, *, batch: bool = False
-    ) -&gt; bool:
+    def delete_attachment(self, docid: str, attname: str, rev: str, *, batch: bool = False) -&gt; bool:
         &#34;&#34;&#34;
         Delete an attachment.
 
@@ -673,9 +663,9 @@ el.replaceWith(d);
                     },
                 ).json()
             )
-        except (CouchDBError, httpx.RequestError) as error:
+        except (CouchDBError, httpx.RequestError):
             if check:
-                raise error
+                raise
             return default_value
 
     def get_attachment(
@@ -789,9 +779,7 @@ el.replaceWith(d);
                 &#39;Precisely one of the arguments &#34;attdata&#34; and  &#34;attloc&#34; must be provided.&#39;
             )
         if content and not content_type:
-            raise ValueError(
-                &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-            )
+            raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
         resource = f&#34;{docid}/{attname}&#34;
         query_kwargs = {&#34;rev&#34;: rev}
         content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -865,7 +853,7 @@ el.replaceWith(d);
         ... })
         &#34;&#34;&#34;
         if partitioned:
-            options = (options or dict()).update({&#34;partitioned&#34;: partitioned})
+            options = (options or {}).update({&#34;partitioned&#34;: partitioned})
         return self.save(
             doc=rm_nones_from_dict(
                 {
@@ -916,7 +904,7 @@ el.replaceWith(d);
         &#34;&#34;&#34;
         batch = &#34;ok&#34; if batch else None
         data = self._put(
-            resource=&#34;%s/%s&#34; % (path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
+            resource=&#34;{}/{}&#34;.format(path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
             body=doc,
             query_kwargs={
                 &#34;batch&#34;: &#34;ok&#34; if batch else None,
@@ -1019,9 +1007,9 @@ el.replaceWith(d);
         -------
         bool :  Operation status.
         &#34;&#34;&#34;
-        return self._put(
-            resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-        ).json()[&#34;ok&#34;]
+        return self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}).json()[
+            &#34;ok&#34;
+        ]
 
     def view(
         self,
@@ -1311,9 +1299,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def bulk_docs(
-    self, docs: list[dict | Document], new_edits: bool = True
-) -&gt; list[dict]:
+<pre><code class="python">def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
     &#34;&#34;&#34;
     The bulk document API allows you to create and update multiple documents at the same time within a single
     request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -1342,9 +1328,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
       - `ok` operation status
       - `rev` the document&#39;s revision
     &#34;&#34;&#34;
-    return self._post(
-        resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-    ).json()</code></pre>
+    return self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}).json()</code></pre>
 </details>
 <div class="desc"><p>The bulk document API allows you to create and update multiple documents at the same time within a single
 request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -1558,9 +1542,7 @@ database. For more info, please refer to
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def create(
-    self, doc: dict | Document, *, batch: bool | None = None
-) -&gt; tuple[str, bool, str]:
+<pre><code class="python">def create(self, doc: dict | Document, *, batch: bool | None = None) -&gt; tuple[str, bool, str]:
     &#34;&#34;&#34;
     Create a new document.
 
@@ -1575,9 +1557,7 @@ database. For more info, please refer to
     -------
     Tuple[str, bool, str] : A tuple consisting of the id, success message &amp; revision.
     &#34;&#34;&#34;
-    data = self._post(
-        body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-    ).json()
+    data = self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}).json()
     return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]</code></pre>
 </details>
 <div class="desc"><p>Create a new document.</p>
@@ -1643,9 +1623,7 @@ database. For more info, please refer to
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def delete_attachment(
-    self, docid: str, attname: str, rev: str, *, batch: bool = False
-) -&gt; bool:
+<pre><code class="python">def delete_attachment(self, docid: str, attname: str, rev: str, *, batch: bool = False) -&gt; bool:
     &#34;&#34;&#34;
     Delete an attachment.
 
@@ -2100,9 +2078,9 @@ the query response. Default is <code>False</code>.</dd>
                 },
             ).json()
         )
-    except (CouchDBError, httpx.RequestError) as error:
+    except (CouchDBError, httpx.RequestError):
         if check:
-            raise error
+            raise
         return default_value</code></pre>
 </details>
 <div class="desc"><p>Get a document by id.</p>
@@ -2401,9 +2379,7 @@ marked as <code>_deleted=true</code> as opposed to being completely purged. For 
             &#39;Precisely one of the arguments &#34;attdata&#34; and  &#34;attloc&#34; must be provided.&#39;
         )
     if content and not content_type:
-        raise ValueError(
-            &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-        )
+        raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
     resource = f&#34;{docid}/{attname}&#34;
     query_kwargs = {&#34;rev&#34;: rev}
     content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -2512,7 +2488,7 @@ Must be provided when passing the <code>content</code> argument.</dd>
     ... })
     &#34;&#34;&#34;
     if partitioned:
-        options = (options or dict()).update({&#34;partitioned&#34;: partitioned})
+        options = (options or {}).update({&#34;partitioned&#34;: partitioned})
     return self.save(
         doc=rm_nones_from_dict(
             {
@@ -2610,7 +2586,7 @@ design document functions.</dd>
     &#34;&#34;&#34;
     batch = &#34;ok&#34; if batch else None
     data = self._put(
-        resource=&#34;%s/%s&#34; % (path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
+        resource=&#34;{}/{}&#34;.format(path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
         body=doc,
         query_kwargs={
             &#34;batch&#34;: &#34;ok&#34; if batch else None,
@@ -2796,9 +2772,9 @@ database, an error occurs.</dd>
     -------
     bool :  Operation status.
     &#34;&#34;&#34;
-    return self._put(
-        resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-    ).json()[&#34;ok&#34;]</code></pre>
+    return self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}).json()[
+        &#34;ok&#34;
+    ]</code></pre>
 </details>
 <div class="desc"><p>Update database security.</p>
 <h2 id="parameters">Parameters</h2>
@@ -3149,7 +3125,7 @@ ViewResult: {
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
 
-    def all_docs(self, keys: Iterable[str] = None, **kwargs) -&gt; ViewResult:
+    def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
         &#34;&#34;&#34;
         Executes the built-in _all_docs view, returning all the documents in the partition.
 
@@ -3164,9 +3140,7 @@ ViewResult: {
         -------
         ViewResult
         &#34;&#34;&#34;
-        return super().all_docs(
-            partition=self.partition_id, keys=keys, **kwargs
-        )
+        return super().all_docs(partition=self.partition_id, keys=keys, **kwargs)
 
     # noinspection PyMethodOverriding
     def info(
@@ -3341,9 +3315,7 @@ ViewResult: {
             update_seq=update_seq,
         )
 
-    def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -&gt; list[dict]:
+    def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;
         See `Database.bulk_docs`.
 
@@ -3653,14 +3625,14 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <div class="desc"><p>Append the instance's partition ID to a string.</p></div>
 </dd>
 <dt id="couchdb3.sync.database.Partition.all_docs"><code class="name flex">
-<span>def <span class="ident">all_docs</span></span>(<span>self, keys: Iterable[str] = None, **kwargs) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
+<span>def <span class="ident">all_docs</span></span>(<span>self, keys: Iterable[str] | None = None, **kwargs) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def all_docs(self, keys: Iterable[str] = None, **kwargs) -&gt; ViewResult:
+<pre><code class="python">def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
     &#34;&#34;&#34;
     Executes the built-in _all_docs view, returning all the documents in the partition.
 
@@ -3675,9 +3647,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
     -------
     ViewResult
     &#34;&#34;&#34;
-    return super().all_docs(
-        partition=self.partition_id, keys=keys, **kwargs
-    )</code></pre>
+    return super().all_docs(partition=self.partition_id, keys=keys, **kwargs)</code></pre>
 </details>
 <div class="desc"><p>Executes the built-in _all_docs view, returning all the documents in the partition.</p>
 <h2 id="parameters">Parameters</h2>
@@ -3701,9 +3671,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def bulk_docs(
-    self, docs: list[dict | Document], new_edits: bool = True
-) -&gt; list[dict]:
+<pre><code class="python">def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
     &#34;&#34;&#34;
     See `Database.bulk_docs`.
 

--- a/docs/sync/index.html
+++ b/docs/sync/index.html
@@ -187,9 +187,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             **kwargs,
         )
 
-    def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -&gt; list[dict]:
+    def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;
         The bulk document API allows you to create and update multiple documents at the same time within a single
         request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -218,9 +216,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
           - `ok` operation status
           - `rev` the document&#39;s revision
         &#34;&#34;&#34;
-        return self._post(
-            resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-        ).json()
+        return self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}).json()
 
     def bulk_get(
         self,
@@ -326,9 +322,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         ).json()
         return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]
 
-    def create(
-        self, doc: dict | Document, *, batch: bool | None = None
-    ) -&gt; tuple[str, bool, str]:
+    def create(self, doc: dict | Document, *, batch: bool | None = None) -&gt; tuple[str, bool, str]:
         &#34;&#34;&#34;
         Create a new document.
 
@@ -343,9 +337,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         -------
         Tuple[str, bool, str] : A tuple consisting of the id, success message &amp; revision.
         &#34;&#34;&#34;
-        data = self._post(
-            body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-        ).json()
+        data = self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}).json()
         return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]
 
     def delete(self, docid: str, rev: str, *, batch: bool | None = None) -&gt; bool:
@@ -371,9 +363,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         )
         return True
 
-    def delete_attachment(
-        self, docid: str, attname: str, rev: str, *, batch: bool = False
-    ) -&gt; bool:
+    def delete_attachment(self, docid: str, attname: str, rev: str, *, batch: bool = False) -&gt; bool:
         &#34;&#34;&#34;
         Delete an attachment.
 
@@ -693,9 +683,9 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
                     },
                 ).json()
             )
-        except (CouchDBError, httpx.RequestError) as error:
+        except (CouchDBError, httpx.RequestError):
             if check:
-                raise error
+                raise
             return default_value
 
     def get_attachment(
@@ -809,9 +799,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
                 &#39;Precisely one of the arguments &#34;attdata&#34; and  &#34;attloc&#34; must be provided.&#39;
             )
         if content and not content_type:
-            raise ValueError(
-                &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-            )
+            raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
         resource = f&#34;{docid}/{attname}&#34;
         query_kwargs = {&#34;rev&#34;: rev}
         content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -885,7 +873,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         ... })
         &#34;&#34;&#34;
         if partitioned:
-            options = (options or dict()).update({&#34;partitioned&#34;: partitioned})
+            options = (options or {}).update({&#34;partitioned&#34;: partitioned})
         return self.save(
             doc=rm_nones_from_dict(
                 {
@@ -936,7 +924,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         &#34;&#34;&#34;
         batch = &#34;ok&#34; if batch else None
         data = self._put(
-            resource=&#34;%s/%s&#34; % (path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
+            resource=&#34;{}/{}&#34;.format(path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
             body=doc,
             query_kwargs={
                 &#34;batch&#34;: &#34;ok&#34; if batch else None,
@@ -1039,9 +1027,9 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         -------
         bool :  Operation status.
         &#34;&#34;&#34;
-        return self._put(
-            resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-        ).json()[&#34;ok&#34;]
+        return self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}).json()[
+            &#34;ok&#34;
+        ]
 
     def view(
         self,
@@ -1331,9 +1319,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def bulk_docs(
-    self, docs: list[dict | Document], new_edits: bool = True
-) -&gt; list[dict]:
+<pre><code class="python">def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
     &#34;&#34;&#34;
     The bulk document API allows you to create and update multiple documents at the same time within a single
     request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -1362,9 +1348,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
       - `ok` operation status
       - `rev` the document&#39;s revision
     &#34;&#34;&#34;
-    return self._post(
-        resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}
-    ).json()</code></pre>
+    return self._post(resource=&#34;_bulk_docs&#34;, body={&#34;docs&#34;: docs, &#34;new_edits&#34;: new_edits}).json()</code></pre>
 </details>
 <div class="desc"><p>The bulk document API allows you to create and update multiple documents at the same time within a single
 request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -1578,9 +1562,7 @@ database. For more info, please refer to
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def create(
-    self, doc: dict | Document, *, batch: bool | None = None
-) -&gt; tuple[str, bool, str]:
+<pre><code class="python">def create(self, doc: dict | Document, *, batch: bool | None = None) -&gt; tuple[str, bool, str]:
     &#34;&#34;&#34;
     Create a new document.
 
@@ -1595,9 +1577,7 @@ database. For more info, please refer to
     -------
     Tuple[str, bool, str] : A tuple consisting of the id, success message &amp; revision.
     &#34;&#34;&#34;
-    data = self._post(
-        body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}
-    ).json()
+    data = self._post(body=doc, query_kwargs={&#34;batch&#34;: &#34;ok&#34; if batch is True else None}).json()
     return data[&#34;id&#34;], data[&#34;ok&#34;], data[&#34;rev&#34;]</code></pre>
 </details>
 <div class="desc"><p>Create a new document.</p>
@@ -1663,9 +1643,7 @@ database. For more info, please refer to
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def delete_attachment(
-    self, docid: str, attname: str, rev: str, *, batch: bool = False
-) -&gt; bool:
+<pre><code class="python">def delete_attachment(self, docid: str, attname: str, rev: str, *, batch: bool = False) -&gt; bool:
     &#34;&#34;&#34;
     Delete an attachment.
 
@@ -2120,9 +2098,9 @@ the query response. Default is <code>False</code>.</dd>
                 },
             ).json()
         )
-    except (CouchDBError, httpx.RequestError) as error:
+    except (CouchDBError, httpx.RequestError):
         if check:
-            raise error
+            raise
         return default_value</code></pre>
 </details>
 <div class="desc"><p>Get a document by id.</p>
@@ -2421,9 +2399,7 @@ marked as <code>_deleted=true</code> as opposed to being completely purged. For 
             &#39;Precisely one of the arguments &#34;attdata&#34; and  &#34;attloc&#34; must be provided.&#39;
         )
     if content and not content_type:
-        raise ValueError(
-            &#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;
-        )
+        raise ValueError(&#39;Argument &#34;content_type&#34; cannot be empty when &#34;content&#34; is provided.&#39;)
     resource = f&#34;{docid}/{attname}&#34;
     query_kwargs = {&#34;rev&#34;: rev}
     content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -2532,7 +2508,7 @@ Must be provided when passing the <code>content</code> argument.</dd>
     ... })
     &#34;&#34;&#34;
     if partitioned:
-        options = (options or dict()).update({&#34;partitioned&#34;: partitioned})
+        options = (options or {}).update({&#34;partitioned&#34;: partitioned})
     return self.save(
         doc=rm_nones_from_dict(
             {
@@ -2630,7 +2606,7 @@ design document functions.</dd>
     &#34;&#34;&#34;
     batch = &#34;ok&#34; if batch else None
     data = self._put(
-        resource=&#34;%s/%s&#34; % (path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
+        resource=&#34;{}/{}&#34;.format(path, doc.get(&#34;_id&#34;)) if path else doc.get(&#34;_id&#34;),
         body=doc,
         query_kwargs={
             &#34;batch&#34;: &#34;ok&#34; if batch else None,
@@ -2816,9 +2792,9 @@ database, an error occurs.</dd>
     -------
     bool :  Operation status.
     &#34;&#34;&#34;
-    return self._put(
-        resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}
-    ).json()[&#34;ok&#34;]</code></pre>
+    return self._put(resource=&#34;_security&#34;, body={&#34;admins&#34;: admins, &#34;members&#34;: members}).json()[
+        &#34;ok&#34;
+    ]</code></pre>
 </details>
 <div class="desc"><p>Update database security.</p>
 <h2 id="parameters">Parameters</h2>
@@ -3169,7 +3145,7 @@ ViewResult: {
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
 
-    def all_docs(self, keys: Iterable[str] = None, **kwargs) -&gt; ViewResult:
+    def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
         &#34;&#34;&#34;
         Executes the built-in _all_docs view, returning all the documents in the partition.
 
@@ -3184,9 +3160,7 @@ ViewResult: {
         -------
         ViewResult
         &#34;&#34;&#34;
-        return super().all_docs(
-            partition=self.partition_id, keys=keys, **kwargs
-        )
+        return super().all_docs(partition=self.partition_id, keys=keys, **kwargs)
 
     # noinspection PyMethodOverriding
     def info(
@@ -3361,9 +3335,7 @@ ViewResult: {
             update_seq=update_seq,
         )
 
-    def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -&gt; list[dict]:
+    def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;
         See `Database.bulk_docs`.
 
@@ -3673,14 +3645,14 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <div class="desc"><p>Append the instance's partition ID to a string.</p></div>
 </dd>
 <dt id="couchdb3.sync.Partition.all_docs"><code class="name flex">
-<span>def <span class="ident">all_docs</span></span>(<span>self, keys: Iterable[str] = None, **kwargs) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
+<span>def <span class="ident">all_docs</span></span>(<span>self, keys: Iterable[str] | None = None, **kwargs) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
 </code></dt>
 <dd>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def all_docs(self, keys: Iterable[str] = None, **kwargs) -&gt; ViewResult:
+<pre><code class="python">def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -&gt; ViewResult:
     &#34;&#34;&#34;
     Executes the built-in _all_docs view, returning all the documents in the partition.
 
@@ -3695,9 +3667,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
     -------
     ViewResult
     &#34;&#34;&#34;
-    return super().all_docs(
-        partition=self.partition_id, keys=keys, **kwargs
-    )</code></pre>
+    return super().all_docs(partition=self.partition_id, keys=keys, **kwargs)</code></pre>
 </details>
 <div class="desc"><p>Executes the built-in _all_docs view, returning all the documents in the partition.</p>
 <h2 id="parameters">Parameters</h2>
@@ -3721,9 +3691,7 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def bulk_docs(
-    self, docs: list[dict | Document], new_edits: bool = True
-) -&gt; list[dict]:
+<pre><code class="python">def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
     &#34;&#34;&#34;
     See `Database.bulk_docs`.
 
@@ -4605,9 +4573,7 @@ view reflects. Default is <code>False</code>.</dd>
         -------
         couchdb3.sync.Database
         &#34;&#34;&#34;
-        self._put(
-            resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-        )
+        self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
         return self.get(name=name)
 
     def dbs_info(self, keys: list[str]) -&gt; list[dict]:
@@ -4652,11 +4618,11 @@ view reflects. Default is <code>False</code>.</dd>
         )
         try:
             db._head()
-        except (NotFoundError, httpx.RequestError) as error:
+        except (NotFoundError, httpx.RequestError):
             if check is True:
-                raise error
-        except CouchDBError as error:
-            raise error
+                raise
+        except CouchDBError:
+            raise
         return db
 
     def delete(self, resource: str | None = None) -&gt; bool:
@@ -4801,9 +4767,9 @@ view reflects. Default is <code>False</code>.</dd>
         try:
             response = self._get(resource=&#34;_up&#34;)
             return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-        except Exception as error:
+        except Exception:
             if raise_exception:
-                raise error
+                raise
             return False</code></pre>
 </details>
 <div class="desc"><p>Abstract Couchdb client</p>
@@ -5005,9 +4971,7 @@ request.</p>
     -------
     couchdb3.sync.Database
     &#34;&#34;&#34;
-    self._put(
-        resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-    )
+    self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
     return self.get(name=name)</code></pre>
 </details>
 <div class="desc"><p>Create a database.</p>
@@ -5130,11 +5094,11 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
     )
     try:
         db._head()
-    except (NotFoundError, httpx.RequestError) as error:
+    except (NotFoundError, httpx.RequestError):
         if check is True:
-            raise error
-    except CouchDBError as error:
-        raise error
+            raise
+    except CouchDBError:
+        raise
     return db</code></pre>
 </details>
 <div class="desc"><p>Get a database by name.</p>
@@ -5478,9 +5442,9 @@ stored.</dd>
     try:
         response = self._get(resource=&#34;_up&#34;)
         return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-    except Exception as error:
+    except Exception:
         if raise_exception:
-            raise error
+            raise
         return False</code></pre>
 </details>
 <div class="desc"><p>Check if the server is up.</p>

--- a/docs/sync/server.html
+++ b/docs/sync/server.html
@@ -299,9 +299,7 @@ el.replaceWith(d);
         -------
         couchdb3.sync.Database
         &#34;&#34;&#34;
-        self._put(
-            resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-        )
+        self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
         return self.get(name=name)
 
     def dbs_info(self, keys: list[str]) -&gt; list[dict]:
@@ -346,11 +344,11 @@ el.replaceWith(d);
         )
         try:
             db._head()
-        except (NotFoundError, httpx.RequestError) as error:
+        except (NotFoundError, httpx.RequestError):
             if check is True:
-                raise error
-        except CouchDBError as error:
-            raise error
+                raise
+        except CouchDBError:
+            raise
         return db
 
     def delete(self, resource: str | None = None) -&gt; bool:
@@ -495,9 +493,9 @@ el.replaceWith(d);
         try:
             response = self._get(resource=&#34;_up&#34;)
             return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-        except Exception as error:
+        except Exception:
             if raise_exception:
-                raise error
+                raise
             return False</code></pre>
 </details>
 <div class="desc"><p>Abstract Couchdb client</p>
@@ -699,9 +697,7 @@ request.</p>
     -------
     couchdb3.sync.Database
     &#34;&#34;&#34;
-    self._put(
-        resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned}
-    )
+    self._put(resource=name, query_kwargs={&#34;q&#34;: q, &#34;n&#34;: n, &#34;partitioned&#34;: partitioned})
     return self.get(name=name)</code></pre>
 </details>
 <div class="desc"><p>Create a database.</p>
@@ -824,11 +820,11 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
     )
     try:
         db._head()
-    except (NotFoundError, httpx.RequestError) as error:
+    except (NotFoundError, httpx.RequestError):
         if check is True:
-            raise error
-    except CouchDBError as error:
-        raise error
+            raise
+    except CouchDBError:
+        raise
     return db</code></pre>
 </details>
 <div class="desc"><p>Get a database by name.</p>
@@ -1172,9 +1168,9 @@ stored.</dd>
     try:
         response = self._get(resource=&#34;_up&#34;)
         return &#34;status&#34; in response.json() and response.json()[&#34;status&#34;] == &#34;ok&#34;
-    except Exception as error:
+    except Exception:
         if raise_exception:
-            raise error
+            raise
         return False</code></pre>
 </details>
 <div class="desc"><p>Check if the server is up.</p>

--- a/docs/utils.html
+++ b/docs/utils.html
@@ -148,9 +148,7 @@ el.replaceWith(d);
     -------
     str : A string containing the keyword-args encoded as URL query-params.
     &#34;&#34;&#34;
-    return parse.urlencode(
-        {key: _handler(val) for key, val in kwargs.items() if val is not None}
-    )</code></pre>
+    return parse.urlencode({key: _handler(val) for key, val in kwargs.items() if val is not None})</code></pre>
 </details>
 <div class="desc"><h2 id="parameters">Parameters</h2>
 <dl>
@@ -161,7 +159,7 @@ el.replaceWith(d);
 <p>str : A string containing the keyword-args encoded as URL query-params.</p></div>
 </dd>
 <dt id="couchdb3.utils.build_url"><code class="name flex">
-<span>def <span class="ident">build_url</span></span>(<span>*, scheme: str, host: str, path: str = None, port: int = None, **kwargs) ‑> str</span>
+<span>def <span class="ident">build_url</span></span>(<span>*, scheme: str, host: str, path: str | None = None, port: int | None = None, **kwargs) ‑> str</span>
 </code></dt>
 <dd>
 <details class="source">
@@ -172,8 +170,8 @@ el.replaceWith(d);
     *,
     scheme: str,
     host: str,
-    path: str = None,
-    port: int = None,
+    path: str | None = None,
+    port: int | None = None,
     **kwargs,
 ) -&gt; str:
     &#34;&#34;&#34;
@@ -258,14 +256,14 @@ el.replaceWith(d);
         TimeoutError,
         httpx.ConnectError,
         httpx.HTTPStatusError,
-    ) as err:
+    ):
         if response.status_code in exceptions.STATUS_CODE_ERROR_MAPPING:
             _ = exceptions.STATUS_CODE_ERROR_MAPPING[response.status_code]
             if _:
                 raise _(response.text)
             else:
                 return
-        raise err</code></pre>
+        raise</code></pre>
 </details>
 <div class="desc"><p>Check if a request yields a successful response.</p>
 <h2 id="parameters">Parameters</h2>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "build>=1.5.0",
     "pdoc>=16.0.0",
     "pdoc3>=0.11.6",
+    "ruff>=0.4",
     "setuptools>=83.0.0",
     "twine>=7.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "couchdb3"
-version = "3.2.0"
+version = "3.2.1"
 description = "A wrapper around the CouchDB API."
 authors = [{ name = "Nikolai Vlahovic", email = "vlahovic.REDACTED_USERlai@gmail.com" }]
 requires-python = ">= 3.11"
@@ -15,9 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "build>=1.5.0",
     "httpx>=0.27,<1.0",
-    "pdoc3>=0.11.6",
 ]
 
 [project.optional-dependencies]
@@ -38,3 +36,18 @@ Issues = "https://github.com/N-Vlahovic/couchdb3/issues"
 [build-system]
 requires = ["uv_build>=0.10.9,<0.11.0"]
 build-backend = "uv_build"
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+ignore = [
+    "EXE001",   # shebang present but file not executable — OS/git artifact
+    "EXE002",   # file executable but no shebang — OS/git artifact
+    "SIM102",   # nested if → single and — intentional in _request auth flow
+    "ASYNC230", # blocking open() in async — no aiofiles dep, bounded read
+    "DTZ005",   # datetime.now() without tz — intentional in test code
+]
+
+[tool.ruff.lint.per-file-ignores]
+"src/couchdb3/sync/base.py" = ["PLC0414"]  # intentional re-export alias

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+uv pip install build --quiet
 if [ -z "$(ls -A dist 2>/dev/null)" ]; then
 	echo "dist folder empty"
 else

--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+uv pip install build twine --quiet
 if [ -z "$(ls -A dist 2>/dev/null)" ]; then
 	echo "dist folder empty"
 else

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+uv pip install build twine --quiet
 if [ -z "$(ls -A dist 2>/dev/null)" ]; then
 	echo "dist folder empty"
 else

--- a/scripts/html.sh
+++ b/scripts/html.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+uv pip install pdoc3 --quiet
 rm -rf docs
 uv run pdoc --html -o docs src/couchdb3 --force
 mv docs/couchdb3/* docs/

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="CouchDB3",
-    version="3.2.0",
+    version="3.2.1",
     author="Nikolai Vlahovic",
     author_email="REDACTED_USERlai@nexup.com",
     description="A wrapper around the CouchDB API.",

--- a/src/couchdb3/aio/async_base.py
+++ b/src/couchdb3/aio/async_base.py
@@ -163,11 +163,7 @@ class AsyncBase:
         """
         try:
             return (
-                next(
-                    _.expires
-                    for _ in self.session.cookies.jar
-                    if _.name == "AuthSession"
-                )
+                next(_.expires for _ in self.session.cookies.jar if _.name == "AuthSession")
                 <= datetime.now(UTC).timestamp()
             )
         except StopIteration:
@@ -516,9 +512,7 @@ class AsyncBase:
         -------
         dict: A dictionary containing the server's or database's info.
         """
-        return (
-            await self._get(resource=f"_partition/{partition}" if partition else None)
-        ).json()
+        return (await self._get(resource=f"_partition/{partition}" if partition else None)).json()
 
     async def rev(self, resource: str) -> str | None:
         """

--- a/src/couchdb3/aio/async_database.py
+++ b/src/couchdb3/aio/async_database.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import httpx
 
-from .async_base import AsyncBase
 from ..document import (
     AttachmentDocument,
     Document,
@@ -23,6 +22,7 @@ from ..utils import (
     validate_db_name,
 )
 from ..view import ViewResult
+from .async_base import AsyncBase
 
 __all__ = [
     "AsyncDatabase",
@@ -159,9 +159,7 @@ class AsyncDatabase(AsyncBase):
         list[dict] : Each item contains `id`, `ok`, and `rev`.
         """
         return (
-            await self._post(
-                resource="_bulk_docs", body={"docs": docs, "new_edits": new_edits}
-            )
+            await self._post(resource="_bulk_docs", body={"docs": docs, "new_edits": new_edits})
         ).json()
 
     async def bulk_get(
@@ -272,15 +270,11 @@ class AsyncDatabase(AsyncBase):
         tuple[str, bool, str] : (id, ok, rev)
         """
         data = (
-            await self._post(
-                body=doc, query_kwargs={"batch": "ok" if batch is True else None}
-            )
+            await self._post(body=doc, query_kwargs={"batch": "ok" if batch is True else None})
         ).json()
         return data["id"], data["ok"], data["rev"]
 
-    async def delete(
-        self, docid: str, rev: str, *, batch: bool | None = None
-    ) -> bool:
+    async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -> bool:
         """
         Delete a document.
 
@@ -571,9 +565,9 @@ class AsyncDatabase(AsyncBase):
                     )
                 ).json()
             )
-        except (CouchDBError, httpx.RequestError) as error:
+        except (CouchDBError, httpx.RequestError):
             if check:
-                raise error
+                raise
             return default_value
 
     async def get_attachment(
@@ -678,9 +672,7 @@ class AsyncDatabase(AsyncBase):
                 'Precisely one of the arguments "content" and "path" must be provided.'
             )
         if content and not content_type:
-            raise ValueError(
-                'Argument "content_type" cannot be empty when "content" is provided.'
-            )
+            raise ValueError('Argument "content_type" cannot be empty when "content" is provided.')
         resource = f"{docid}/{attname}"
         query_kwargs = {"rev": rev}
         content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -876,9 +868,7 @@ class AsyncDatabase(AsyncBase):
         bool : Operation status.
         """
         return (
-            await self._put(
-                resource="_security", body={"admins": admins, "members": members}
-            )
+            await self._put(resource="_security", body={"admins": admins, "members": members})
         ).json()["ok"]
 
     async def view(
@@ -1089,9 +1079,7 @@ class AsyncPartition(AsyncDatabase):
     def __repr__(self) -> str:
         return f"{super().__repr__()}/{self.partition_id}"
 
-    async def all_docs(
-        self, keys: Iterable[str] | None = None, **kwargs
-    ) -> ViewResult:
+    async def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -> ViewResult:
         """
         Executes the built-in _all_docs view, returning all documents in the partition.
 
@@ -1106,9 +1094,7 @@ class AsyncPartition(AsyncDatabase):
         -------
         ViewResult
         """
-        return await super().all_docs(
-            partition=self.partition_id, keys=keys, **kwargs
-        )
+        return await super().all_docs(partition=self.partition_id, keys=keys, **kwargs)
 
     async def info(self) -> dict:
         """
@@ -1211,18 +1197,14 @@ class AsyncPartition(AsyncDatabase):
             update_seq=update_seq,
         )
 
-    async def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -> list[dict]:
+    async def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -> list[dict]:
         """See `AsyncDatabase.bulk_docs`. Prepends partition ID to document IDs."""
         return await super().bulk_docs(
             docs=[self.add_partition_to_doc(doc) for doc in docs],
             new_edits=new_edits,
         )
 
-    async def bulk_get(
-        self, docs: list[dict | Document], revs: bool = False
-    ) -> list[dict]:
+    async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -> list[dict]:
         """See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs."""
         return await super().bulk_get(
             docs=[self.add_partition_to_doc(doc) for doc in docs],
@@ -1253,9 +1235,7 @@ class AsyncPartition(AsyncDatabase):
             batch=batch,
         )
 
-    async def delete(
-        self, docid: str, rev: str, *, batch: bool | None = None
-    ) -> bool:
+    async def delete(self, docid: str, rev: str, *, batch: bool | None = None) -> bool:
         """See `AsyncDatabase.delete`. Prepends partition ID to document ID."""
         return await super().delete(
             docid=self.add_partition_to_str(docid),

--- a/src/couchdb3/aio/async_server.py
+++ b/src/couchdb3/aio/async_server.py
@@ -2,8 +2,6 @@
 
 import httpx
 
-from .async_base import AsyncBase
-from .async_database import AsyncDatabase
 from ..exceptions import (
     ConflictError,
     CouchDBError,
@@ -18,6 +16,8 @@ from ..utils import (
     validate_proxy,
     validate_user_id,
 )
+from .async_base import AsyncBase
+from .async_database import AsyncDatabase
 
 __all__ = ["AsyncServer"]
 
@@ -265,9 +265,7 @@ class AsyncServer(AsyncBase):
         -------
         AsyncDatabase
         """
-        await self._put(
-            resource=name, query_kwargs={"q": q, "n": n, "partitioned": partitioned}
-        )
+        await self._put(resource=name, query_kwargs={"q": q, "n": n, "partitioned": partitioned})
         return await self.get(name=name)
 
     async def dbs_info(self, keys: list[str]) -> list[dict]:
@@ -311,11 +309,11 @@ class AsyncServer(AsyncBase):
         )
         try:
             await db._head()
-        except (NotFoundError, httpx.RequestError) as error:
+        except (NotFoundError, httpx.RequestError):
             if check is True:
-                raise error
-        except CouchDBError as error:
-            raise error
+                raise
+        except CouchDBError:
+            raise
         return db
 
     async def delete(self, resource: str | None = None) -> bool:
@@ -430,7 +428,7 @@ class AsyncServer(AsyncBase):
         try:
             response = await self._get(resource="_up")
             return "status" in response.json() and response.json()["status"] == "ok"
-        except Exception as error:
+        except Exception:
             if raise_exception:
-                raise error
+                raise
             return False

--- a/src/couchdb3/document.py
+++ b/src/couchdb3/document.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 __all__ = [
-    "DictBase",
     "AttachmentDocument",
+    "DictBase",
     "Document",
     "SecurityDocument",
     "SecurityDocumentElement",

--- a/src/couchdb3/sync/base.py
+++ b/src/couchdb3/sync/base.py
@@ -79,9 +79,7 @@ class Base:
             self._owns_session = True
         self._user = user
         self._password = password
-        self._auth = (
-            httpx.BasicAuth(user, password) if user and password else None
-        )
+        self._auth = httpx.BasicAuth(user, password) if user and password else None
         self.auth_method = auth_method
         self.timeout = timeout
 
@@ -474,11 +472,7 @@ class Base:
             # httpx.Client.cookies.jar yields http.cookiejar.Cookie objects which
             # carry the .name and .expires attributes we need.
             return (
-                next(
-                    _.expires
-                    for _ in self.session.cookies.jar
-                    if _.name == "AuthSession"
-                )
+                next(_.expires for _ in self.session.cookies.jar if _.name == "AuthSession")
                 <= datetime.now(UTC).timestamp()
             )
         except StopIteration:
@@ -530,9 +524,7 @@ class Base:
         -------
         Dict: A dictionary containing the server's or database's info.
         """
-        return self._get(
-            resource=f"_partition/{partition}" if partition else None
-        ).json()
+        return self._get(resource=f"_partition/{partition}" if partition else None).json()
 
     def rev(self, resource: str) -> str | None:
         """
@@ -557,6 +549,3 @@ class Base:
         except exceptions.NotFoundError:
             pass
         return rev
-
-
-

--- a/src/couchdb3/sync/database.py
+++ b/src/couchdb3/sync/database.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import httpx
 
-from .base import Base
 from ..document import (
     AttachmentDocument,
     Document,
@@ -23,6 +22,7 @@ from ..utils import (
     validate_db_name,
 )
 from ..view import ViewResult
+from .base import Base
 
 __all__ = [
     "Database",
@@ -142,9 +142,7 @@ class Database(Base):
             **kwargs,
         )
 
-    def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -> list[dict]:
+    def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -> list[dict]:
         """
         The bulk document API allows you to create and update multiple documents at the same time within a single
         request. The basic operation is similar to creating or updating a single document, except that you batch the
@@ -173,9 +171,7 @@ class Database(Base):
           - `ok` operation status
           - `rev` the document's revision
         """
-        return self._post(
-            resource="_bulk_docs", body={"docs": docs, "new_edits": new_edits}
-        ).json()
+        return self._post(resource="_bulk_docs", body={"docs": docs, "new_edits": new_edits}).json()
 
     def bulk_get(
         self,
@@ -281,9 +277,7 @@ class Database(Base):
         ).json()
         return data["id"], data["ok"], data["rev"]
 
-    def create(
-        self, doc: dict | Document, *, batch: bool | None = None
-    ) -> tuple[str, bool, str]:
+    def create(self, doc: dict | Document, *, batch: bool | None = None) -> tuple[str, bool, str]:
         """
         Create a new document.
 
@@ -298,9 +292,7 @@ class Database(Base):
         -------
         Tuple[str, bool, str] : A tuple consisting of the id, success message & revision.
         """
-        data = self._post(
-            body=doc, query_kwargs={"batch": "ok" if batch is True else None}
-        ).json()
+        data = self._post(body=doc, query_kwargs={"batch": "ok" if batch is True else None}).json()
         return data["id"], data["ok"], data["rev"]
 
     def delete(self, docid: str, rev: str, *, batch: bool | None = None) -> bool:
@@ -326,9 +318,7 @@ class Database(Base):
         )
         return True
 
-    def delete_attachment(
-        self, docid: str, attname: str, rev: str, *, batch: bool = False
-    ) -> bool:
+    def delete_attachment(self, docid: str, attname: str, rev: str, *, batch: bool = False) -> bool:
         """
         Delete an attachment.
 
@@ -648,9 +638,9 @@ class Database(Base):
                     },
                 ).json()
             )
-        except (CouchDBError, httpx.RequestError) as error:
+        except (CouchDBError, httpx.RequestError):
             if check:
-                raise error
+                raise
             return default_value
 
     def get_attachment(
@@ -764,9 +754,7 @@ class Database(Base):
                 'Precisely one of the arguments "attdata" and  "attloc" must be provided.'
             )
         if content and not content_type:
-            raise ValueError(
-                'Argument "content_type" cannot be empty when "content" is provided.'
-            )
+            raise ValueError('Argument "content_type" cannot be empty when "content" is provided.')
         resource = f"{docid}/{attname}"
         query_kwargs = {"rev": rev}
         content_type = content_type if content_type else mimetypes.guess_type(path)[0]
@@ -840,7 +828,7 @@ class Database(Base):
         ... })
         """
         if partitioned:
-            options = (options or dict()).update({"partitioned": partitioned})
+            options = (options or {}).update({"partitioned": partitioned})
         return self.save(
             doc=rm_nones_from_dict(
                 {
@@ -891,7 +879,7 @@ class Database(Base):
         """
         batch = "ok" if batch else None
         data = self._put(
-            resource="%s/%s" % (path, doc.get("_id")) if path else doc.get("_id"),
+            resource="{}/{}".format(path, doc.get("_id")) if path else doc.get("_id"),
             body=doc,
             query_kwargs={
                 "batch": "ok" if batch else None,
@@ -994,9 +982,9 @@ class Database(Base):
         -------
         bool :  Operation status.
         """
-        return self._put(
-            resource="_security", body={"admins": admins, "members": members}
-        ).json()["ok"]
+        return self._put(resource="_security", body={"admins": admins, "members": members}).json()[
+            "ok"
+        ]
 
     def view(
         self,
@@ -1239,7 +1227,7 @@ class Partition(Database):
     def __repr__(self) -> str:
         return f"{super().__repr__()}/{self.partition_id}"
 
-    def all_docs(self, keys: Iterable[str] = None, **kwargs) -> ViewResult:
+    def all_docs(self, keys: Iterable[str] | None = None, **kwargs) -> ViewResult:
         """
         Executes the built-in _all_docs view, returning all the documents in the partition.
 
@@ -1254,9 +1242,7 @@ class Partition(Database):
         -------
         ViewResult
         """
-        return super().all_docs(
-            partition=self.partition_id, keys=keys, **kwargs
-        )
+        return super().all_docs(partition=self.partition_id, keys=keys, **kwargs)
 
     # noinspection PyMethodOverriding
     def info(
@@ -1431,9 +1417,7 @@ class Partition(Database):
             update_seq=update_seq,
         )
 
-    def bulk_docs(
-        self, docs: list[dict | Document], new_edits: bool = True
-    ) -> list[dict]:
+    def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -> list[dict]:
         """
         See `Database.bulk_docs`.
 

--- a/src/couchdb3/sync/server.py
+++ b/src/couchdb3/sync/server.py
@@ -3,8 +3,6 @@
 
 import httpx
 
-from .base import Base
-from .database import Database
 from ..exceptions import (
     ConflictError,
     CouchDBError,
@@ -19,6 +17,8 @@ from ..utils import (
     validate_proxy,
     validate_user_id,
 )
+from .base import Base
+from .database import Database
 
 __all__ = ["Server"]
 
@@ -267,9 +267,7 @@ class Server(Base):
         -------
         couchdb3.sync.Database
         """
-        self._put(
-            resource=name, query_kwargs={"q": q, "n": n, "partitioned": partitioned}
-        )
+        self._put(resource=name, query_kwargs={"q": q, "n": n, "partitioned": partitioned})
         return self.get(name=name)
 
     def dbs_info(self, keys: list[str]) -> list[dict]:
@@ -314,11 +312,11 @@ class Server(Base):
         )
         try:
             db._head()
-        except (NotFoundError, httpx.RequestError) as error:
+        except (NotFoundError, httpx.RequestError):
             if check is True:
-                raise error
-        except CouchDBError as error:
-            raise error
+                raise
+        except CouchDBError:
+            raise
         return db
 
     def delete(self, resource: str | None = None) -> bool:
@@ -463,7 +461,7 @@ class Server(Base):
         try:
             response = self._get(resource="_up")
             return "status" in response.json() and response.json()["status"] == "ok"
-        except Exception as error:
+        except Exception:
             if raise_exception:
-                raise error
+                raise
             return False

--- a/src/couchdb3/utils.py
+++ b/src/couchdb3/utils.py
@@ -86,7 +86,7 @@ VALID_SCHEMES: set[str] = {"http", "https", "socks5"}
 
 def _handler(x: Any) -> str:
     if isinstance(x, (Generator, map, list, set, tuple)):
-        return "[%s]" % ",".join(f'"{_handler(_)}"' for _ in x)
+        return "[{}]".format(",".join(f'"{_handler(_)}"' for _ in x))
     elif isinstance(x, dict):
         return str({key: _handler(val) for key, val in x.items()})
     elif isinstance(x, bool):
@@ -125,17 +125,15 @@ def build_query(
     -------
     str : A string containing the keyword-args encoded as URL query-params.
     """
-    return parse.urlencode(
-        {key: _handler(val) for key, val in kwargs.items() if val is not None}
-    )
+    return parse.urlencode({key: _handler(val) for key, val in kwargs.items() if val is not None})
 
 
 def build_url(
     *,
     scheme: str,
     host: str,
-    path: str = None,
-    port: int = None,
+    path: str | None = None,
+    port: int | None = None,
     **kwargs,
 ) -> str:
     """
@@ -292,14 +290,14 @@ def check_response(response: httpx.Response) -> None:
         TimeoutError,
         httpx.ConnectError,
         httpx.HTTPStatusError,
-    ) as err:
+    ):
         if response.status_code in exceptions.STATUS_CODE_ERROR_MAPPING:
             _ = exceptions.STATUS_CODE_ERROR_MAPPING[response.status_code]
             if _:
                 raise _(response.text)
             else:
                 return
-        raise err
+        raise
 
 
 def extract_url_data(url: str) -> dict:

--- a/tests/credentials.py
+++ b/tests/credentials.py
@@ -39,7 +39,7 @@ env_file_path: str = f"{proj_path}/.env"
 env_file: dict
 if os.path.isfile(env_file_path):
     with open(env_file_path, "r", encoding="utf-8") as _:
-        env_file = {k: v for k, v in map(lambda _: _.strip().split("="), _.readlines())}
+        env_file = {k: v for k, v in (_.strip().split("=") for _ in _)}
 else:
     env_file = {}
 

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -5,10 +5,10 @@ import random
 import string
 import unittest
 
-from couchdb3.aio import AsyncDatabase, AsyncPartition, AsyncServer
+from couchdb3.aio import AsyncPartition, AsyncServer
 from couchdb3.document import AttachmentDocument, Document
 from couchdb3.sync import Server
-from couchdb3.utils import MimeTypeEnum, user_name_to_id
+from couchdb3.utils import MimeTypeEnum
 from couchdb3.view import ViewResult, ViewRow
 from tests.credentials import (
     ATTACHMENT_PATH_HTML,
@@ -30,16 +30,12 @@ P_ID: str = "p0"
 VIEW_ID: str = "document-view"
 
 # Sync client for atexit cleanup only
-_SYNC_CLIENT: Server = Server(
-    url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
-)
+_SYNC_CLIENT: Server = Server(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
 
 
 class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
-        self.server = AsyncServer(
-            url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
-        )
+        self.server = AsyncServer(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
         all_dbs = await self.server.all_dbs()
         if DB_NAME in all_dbs:
             self.db = await self.server.get(DB_NAME)
@@ -48,34 +44,24 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         if DB_NAME_PARTITIONED in all_dbs:
             self.db_partitioned = await self.server.get(DB_NAME_PARTITIONED)
         else:
-            self.db_partitioned = await self.server.create(
-                DB_NAME_PARTITIONED, partitioned=True
-            )
+            self.db_partitioned = await self.server.create(DB_NAME_PARTITIONED, partitioned=True)
 
     async def asyncTearDown(self):
         await self.server.aclose()
 
     async def test_all_docs(self):
-        docs = [
-            {"_id": f"test-async-all-docs-{i}", "name": f"Document {i}"}
-            for i in range(5)
-        ]
+        docs = [{"_id": f"test-async-all-docs-{i}", "name": f"Document {i}"} for i in range(5)]
         await self.db.bulk_docs(docs=docs)
         result = await self.db.all_docs(keys=[d["_id"] for d in docs])
         self.assertIsInstance(result, ViewResult)
         self.assertEqual(len(result.rows), 5)
-        result = await self.db.all_docs(
-            keys=[d["_id"] for d in docs], include_docs=True
-        )
+        result = await self.db.all_docs(keys=[d["_id"] for d in docs], include_docs=True)
         for row in result.rows:
             self.assertIsInstance(row, ViewRow)
             self.assertIsInstance(row.doc, Document)
 
     async def test_bulk_docs(self):
-        docs = [
-            {"_id": f"test-async-bulk-{i}", "name": f"Document {i}"}
-            for i in range(5)
-        ]
+        docs = [{"_id": f"test-async-bulk-{i}", "name": f"Document {i}"} for i in range(5)]
         results = await self.db.bulk_docs(docs=docs)
         self.assertIsInstance(results, list)
         for doc, res in zip(docs, results):
@@ -84,14 +70,9 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(res["ok"])
 
     async def test_bulk_get(self):
-        docs = [
-            {"_id": f"test-async-bulk-get-{i}", "name": f"Document {i}"}
-            for i in range(5)
-        ]
+        docs = [{"_id": f"test-async-bulk-get-{i}", "name": f"Document {i}"} for i in range(5)]
         await self.db.bulk_docs(docs=docs)
-        results = await self.db.bulk_get(
-            docs=[{"id": d["_id"]} for d in docs]
-        )
+        results = await self.db.bulk_get(docs=[{"id": d["_id"]} for d in docs])
         self.assertIsInstance(results, list)
         for res in results:
             self.assertIn("id", res)
@@ -128,24 +109,13 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
             rev=rev,
         )
         rev = await self.db.rev(docid)
-        self.assertTrue(
-            await self.db.delete_attachment(
-                docid=docid, attname=attname, rev=rev
-            )
-        )
+        self.assertTrue(await self.db.delete_attachment(docid=docid, attname=attname, rev=rev))
 
     async def test_find(self):
-        await self.db.save_index(
-            index={"fields": ["type"]}, name="async-type-idx"
-        )
-        docs = [
-            {"_id": f"test-async-find-{i}", "type": "async-find-test"}
-            for i in range(3)
-        ]
+        await self.db.save_index(index={"fields": ["type"]}, name="async-type-idx")
+        docs = [{"_id": f"test-async-find-{i}", "type": "async-find-test"} for i in range(3)]
         await self.db.bulk_docs(docs=docs)
-        result = await self.db.find(
-            {"type": {"$eq": "async-find-test"}}, fields=["_id", "type"]
-        )
+        result = await self.db.find({"type": {"$eq": "async-find-test"}}, fields=["_id", "type"])
         self.assertIn("docs", result)
         self.assertIsInstance(result["docs"], list)
 
@@ -236,6 +206,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
     async def test_security(self):
         from couchdb3.document import SecurityDocument
+
         sec = await self.db.security()
         self.assertIsInstance(sec, SecurityDocument)
 
@@ -243,9 +214,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         docid = "test-async-view-doc"
         db = await self.server.get(DB_NAME)
         if not await db.rev(f"_design/{DDOC_ID}"):
-            await db.put_design(
-                DDOC_ID, views={VIEW_ID: {"map": DOCUMENT_VIEW}}
-            )
+            await db.put_design(DDOC_ID, views={VIEW_ID: {"map": DOCUMENT_VIEW}})
         if not await db.rev(docid):
             await db.save({"_id": docid, "type": "document"})
         result = await db.view(DDOC_ID, VIEW_ID)
@@ -254,9 +223,7 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
 
 class TestAsyncPartition(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
-        self.server = AsyncServer(
-            url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
-        )
+        self.server = AsyncServer(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
         all_dbs = await self.server.all_dbs()
         if DB_NAME_PARTITIONED not in all_dbs:
             await self.server.create(DB_NAME_PARTITIONED, partitioned=True)

--- a/tests/test_async_server.py
+++ b/tests/test_async_server.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import asyncio
 import atexit
 import unittest
 
@@ -12,16 +11,12 @@ from tests.credentials import COUCHDB0_URL, COUCHDB_PASSWORD, COUCHDB_USER
 TEST_DB_NAME: str = "test-async-db"
 
 # Sync client for atexit cleanup only
-_SYNC_CLIENT: Server = Server(
-    url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
-)
+_SYNC_CLIENT: Server = Server(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
 
 
 class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
-        self.client = AsyncServer(
-            url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
-        )
+        self.client = AsyncServer(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
 
     async def asyncTearDown(self):
         await self.client.aclose()
@@ -45,9 +40,7 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
 
     async def test_check_user(self):
         self.assertTrue(
-            await self.client.check_user(
-                username=COUCHDB_USER, password=COUCHDB_PASSWORD
-            )
+            await self.client.check_user(username=COUCHDB_USER, password=COUCHDB_PASSWORD)
         )
 
     async def test_create(self):
@@ -96,9 +89,7 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.get("ok"))
 
     async def test_rev(self):
-        self.assertIsInstance(
-            await self.client.rev("_users/_design/_auth"), str
-        )
+        self.assertIsInstance(await self.client.rev("_users/_design/_auth"), str)
         self.assertIsNone(await self.client.rev("_users/test"))
 
     async def test_save_user(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,9 +25,7 @@ from tests.credentials import (
 )
 
 
-def get_or_create_db(
-    db_name: str, client: Server, partitioned: bool = False
-) -> Database:
+def get_or_create_db(db_name: str, client: Server, partitioned: bool = False) -> Database:
     return (
         client.get(db_name)
         if db_name in client
@@ -59,7 +57,7 @@ class TestDatabase(unittest.TestCase):
         result = DB.all_docs(keys=[_["_id"] for _ in docs][:5])
         self.assertIsInstance(result, ViewResult)
         self.assertListEqual([_["_id"] for _ in docs][:5], [_.id for _ in result.rows])
-        result = DB.all_docs(keys=map(lambda _: _["_id"], docs), include_docs=True)
+        result = DB.all_docs(keys=(_["_id"] for _ in docs), include_docs=True)
         for _ in result.rows:
             self.assertIsInstance(_, ViewRow)
             self.assertTrue(_.doc)
@@ -196,8 +194,8 @@ class TestDatabase(unittest.TestCase):
         DB.create(doc)
         dbdoc = DB[docid]
         self.assertIsInstance(dbdoc, Document)
-        for key in doc:
-            self.assertEqual(doc[key], dbdoc[key])
+        for key, value in doc.items():
+            self.assertEqual(value, dbdoc[key])
 
     def test_delete_attachment(self):
         docid = "test-doc-delete-attachment"
@@ -215,9 +213,7 @@ class TestDatabase(unittest.TestCase):
                 content_type=content_type,
                 rev=DB.rev(docid),
             )
-            self.assertTrue(
-                DB.delete_attachment(docid=docid, attname=attname, rev=result[2])
-            )
+            self.assertTrue(DB.delete_attachment(docid=docid, attname=attname, rev=result[2]))
 
     def test_attachment_via_path(self):
         docid = self.test_attachment_via_path.__name__.replace("_", "-")
@@ -230,9 +226,7 @@ class TestDatabase(unittest.TestCase):
             ("test.zip", ATTACHMENT_PATH_ZIP),
             ("test.pdf", ATTACHMENT_PATH_PDF),
         ]:
-            DB.put_attachment(
-                docid=docid, attname=attname, path=path, rev=DB.rev(docid)
-            )
+            DB.put_attachment(docid=docid, attname=attname, path=path, rev=DB.rev(docid))
             response = DB.get_attachment(docid=docid, attname=attname)
             self.assertIsInstance(response, AttachmentDocument)
             self.assertIsInstance(response.content, bytes)
@@ -308,9 +302,7 @@ class TestDatabase(unittest.TestCase):
             ("test.txt", ATTACHMENT_PATH_TXT),
             ("test.zip", ATTACHMENT_PATH_ZIP),
         ]:
-            results = DB.put_attachment(
-                docid=docid, attname=attname, path=path, rev=DB.rev(docid)
-            )
+            results = DB.put_attachment(docid=docid, attname=attname, path=path, rev=DB.rev(docid))
             self.assertEqual(results[0], docid)
             self.assertEqual(results[1], True)
             self.assertEqual(results[2], DB.rev(docid))

--- a/tests/test_partitioned_database.py
+++ b/tests/test_partitioned_database.py
@@ -14,9 +14,7 @@ from tests.credentials import (
 CLIENT: Server = Server(COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
 DB_NAME: str = "tmp-test-partitioned-db"
 DB: Database = (
-    CLIENT.get(DB_NAME)
-    if DB_NAME in CLIENT
-    else CLIENT.create(DB_NAME, partitioned=True)
+    CLIENT.get(DB_NAME) if DB_NAME in CLIENT else CLIENT.create(DB_NAME, partitioned=True)
 )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,9 +29,7 @@ class TestClient(unittest.TestCase):
             self.assertIsInstance(_, str)
 
     def test_check_user(self):
-        self.assertTrue(
-            CLIENT.check_user(username=COUCHDB_USER, password=COUCHDB_PASSWORD)
-        )
+        self.assertTrue(CLIENT.check_user(username=COUCHDB_USER, password=COUCHDB_PASSWORD))
 
     def test_create(self):
         db = CLIENT.create(name=TEST_DB_NAME, partitioned=True)
@@ -80,9 +78,7 @@ class TestClient(unittest.TestCase):
 
     def test_save_user(self):
         user_id = "org.couchdb.user:john"
-        ok, _id, _rev = CLIENT.save_user(
-            user_id=user_id, name="john", password="secret123"
-        )
+        ok, _id, _rev = CLIENT.save_user(user_id=user_id, name="john", password="secret123")
         self.assertEqual(ok, True)
         self.assertEqual(_id, user_id)
         self.assertIsInstance(_rev, str)
@@ -92,9 +88,7 @@ class TestClient(unittest.TestCase):
         self.assertFalse(Server("http://admin:secret@localhost:1234").up())
 
     def test_with_context(self):
-        with Server(
-            url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
-        ) as client:
+        with Server(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD) as client:
             self.assertIsInstance(client, Server)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -181,12 +181,10 @@ wheels = [
 
 [[package]]
 name = "couchdb3"
-version = "3.2.0"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
-    { name = "build" },
     { name = "httpx" },
-    { name = "pdoc3" },
 ]
 
 [package.optional-dependencies]
@@ -200,11 +198,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "build", specifier = ">=1.5.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "pdoc", marker = "extra == 'dev'", specifier = ">=16.0.0" },
-    { name = "pdoc3", specifier = ">=0.11.6" },
     { name = "pdoc3", marker = "extra == 'dev'", specifier = ">=0.11.6" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=83.0.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=7.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,7 @@ dev = [
     { name = "build" },
     { name = "pdoc" },
     { name = "pdoc3" },
+    { name = "ruff" },
     { name = "setuptools" },
     { name = "twine" },
 ]
@@ -202,6 +203,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "pdoc", marker = "extra == 'dev'", specifier = ">=16.0.0" },
     { name = "pdoc3", marker = "extra == 'dev'", specifier = ">=0.11.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=83.0.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=7.0.0" },
 ]
@@ -705,6 +707,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/5a449b9162e49b139d72f61672bd3ac1d790221f796d3304e2241fff4c58/ruff-0.16.7.tar.gz", hash = "sha256:5f71d004ac1263b22fa39462ac5ae618a4b77d58981af2cc79bf79a29c12b1a6", size = 4924184, upload-time = "2026-09-10T18:04:06.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/b2/c80aeeb7f9e469c0d63a85d2f1ab6e1ebfbe10ea7a8d2438b7e09e3ff09e/ruff-0.16.7-py3-none-linux_armv6l.whl", hash = "sha256:727307773e7c7f9181d3ed3a2484186e56c1fa1874255911c74585eb2c7c19f9", size = 10048917, upload-time = "2026-09-10T18:03:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/96/20bb7bcae008004df52afcb7ac83432d4a467f2c17b672fe46d26be231c5/ruff-0.16.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9d61c258deabf58f34c67bd4bb4d939c7f2e6b5f0e59c1cdd1cf771b11cde929", size = 10242929, upload-time = "2026-09-10T18:03:32.706Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b2/f184b0d5abec02db69cfd7e49b688ae0237554528ca777136c613bf36bee/ruff-0.16.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7ab81118df8945e0193d0240712aa4496573595b75185c3636ed825592a0f728", size = 9847245, upload-time = "2026-09-10T18:03:34.509Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2d/db1633a641866ed801e34cc6b60ef236c5e16f9b2124ab1d49cc24a5fe4f/ruff-0.16.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c196c968874fc8019da8e7163de7a1a370f111e2309b4b7dfea0fce950198d0", size = 9961780, upload-time = "2026-09-10T18:03:36.618Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/98/edea21e1a3e38dbbc3bf6bb068b863b3b06184cf8533a4c7dbbe208a89d5/ruff-0.16.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac8c3bd0a7e10ad31e6ce51e7a99f3cb772e69aecdd6b9ea7e99b362f62a62c0", size = 9866337, upload-time = "2026-09-10T18:03:38.805Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/11/a15e60d4c87b214646f116ca9d204475bf993ee1047459bc9a360fd4d6d1/ruff-0.16.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:398d3988edde000b5c75dc1b3f584708da9bc990de069c18909142580fec1af9", size = 10562512, upload-time = "2026-09-10T18:03:40.71Z" },
+    { url = "https://files.pythonhosted.org/packages/29/42/eaff4c9b6d0c7cdf56df313a17e89ae854f5bbc0b0c8f9cce19be0ab7a8f/ruff-0.16.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce05b62b770a8217c4646a9c4139fca00efe8fe5d71f87df2b243ff20d4584d1", size = 11302938, upload-time = "2026-09-10T18:03:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/43/c75aa59a4ec181fe2ec06cab30e198c1c6d107229a9f008ae3a7c16cabd8/ruff-0.16.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af1b576fddb9d9ef2ececfb5fadcd6a624b25070ed85e3cfcfe449fc3ff6a7b9", size = 10840857, upload-time = "2026-09-10T18:03:44.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/33/81f3da371942ea031105ba679d8d6e28ec1660ccd690a45f42d381161356/ruff-0.16.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ce7f8f22df67c93ed96c717f9128eadb797144ac2bad475cf536f31d6100c55", size = 10370001, upload-time = "2026-09-10T18:03:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0b/6345fb4dbf6dd0ed1cfe5d18391dc9c3f59cc81622a7b0a65b84b3e730ba/ruff-0.16.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:06d0e93d04f392996435ebd600c153f65b47d73fbec2415aa99c5ee5756b3a5f", size = 10548735, upload-time = "2026-09-10T18:03:48.658Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4d/c5576adf511f92a328e5569dda190ecdd430da51f1a649f3a4a2fd73e21e/ruff-0.16.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:142151a5e7b93c1b11111337142f89dd2fbfee92161225c99a97222f22e32656", size = 10108496, upload-time = "2026-09-10T18:03:50.563Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8c/667d83c16199a17a56adc6b0bd4c3beb5b767a2babcd16a56f76f9be7fd6/ruff-0.16.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e6651f97a342d8b35d54d8991544ca22169b86dc54111cb604666940c431b750", size = 9860136, upload-time = "2026-09-10T18:03:52.621Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/78d401106731999a1dd20cc5a6961e37e1eb9397a3b589f73f3a5ce146a3/ruff-0.16.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ef140c6eb935fa9a84c9c607dfb2cb1b85843c192e79265b0c54f35f557ea8e5", size = 10286290, upload-time = "2026-09-10T18:03:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/56f9c3a8b755df93a0ad318b2147bf4ef5dae9a7e5ec61c460109c67957f/ruff-0.16.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:53e39506a730fadeee0d998ed5946f30671f0db240c6c7c73bdabbe33604bb6f", size = 10745048, upload-time = "2026-09-10T18:03:57.299Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ea/7f9b938a63ece4bec677ad7f9f7fa02df3383db1949ed93a382441c09a87/ruff-0.16.7-py3-none-win32.whl", hash = "sha256:2ea3470fcebcbc5df2fb0c6f3b90333fa9084c534e0111c038fa4a6ab9f1c4b7", size = 10059082, upload-time = "2026-09-10T18:03:59.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/11/480a6973a927aa653e1cead6a6416008640e03a99d05b34c0434b8c6c366/ruff-0.16.7-py3-none-win_amd64.whl", hash = "sha256:7ac26aca826e9e21d0f1cb25b54ac660760a9fdd094d3e4df9848232be98cfc6", size = 10593368, upload-time = "2026-09-10T18:04:01.999Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4b/51327018d056f0dad2c2238f26d1fb0f53707a9d91b75dea6d1b3039f136/ruff-0.16.7-py3-none-win_arm64.whl", hash = "sha256:aab7f39e2c9df6c596216070f98eef1207b94f8516cca20c808826974971855b", size = 10412401, upload-time = "2026-09-10T18:04:04.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview
Style and tooling cleanup pass. No public API changes — patch version bump (`3.2.0` → `3.2.1`).

## Changes

### `pyproject.toml`
- Runtime `dependencies` cleaned to `httpx>=0.27,<1.0` only (removed `build`, `pdoc3` which are dev-only tools)
- Added `ruff>=0.4` to `[project.optional-dependencies] dev`
- Added `[tool.ruff]` config (linting + formatting rules, ignored rules documented with rationale)

### Ruff — 46 errors → 0
All issues resolved via `ruff check --fix --unsafe-fixes` + manual fixes:
- `I001` — import block sorting across `sync/` and `aio/` files
- `F401` — removed unused imports in test files (`asyncio`, `AsyncDatabase`, `user_name_to_id`)
- `TRY201` — `raise error` → bare `raise` in all `except` blocks
- `RUF022` — sorted `__all__` in `document.py`
- `RUF013` — implicit `Optional` → explicit `str | None` in `utils.py` and `sync/database.py`
- `UP031` — `%` format → f-strings in `utils.py` and `sync/database.py`
- `C408` — `dict()` → `{}` literal in `sync/database.py`
- `C417` — `map(lambda ...)` → generator expressions in `tests/`
- `PLC0206` — `for key in doc` → `for key, value in doc.items()`

Suppressed (with rationale in `pyproject.toml`):
- `EXE001`/`EXE002` — shebang vs file permission mismatch, OS/git artifact
- `SIM102` — intentional nested `if` in `_request` auth flow
- `ASYNC230` — blocking `open()` in async `put_attachment`, bounded read, no `aiofiles` dep
- `DTZ005` — `datetime.now()` without tz in test code
- `PLC0414` per-file for `sync/base.py` — intentional re-export alias

### `scripts/`
- `build.sh`, `deploy.sh`, `deploy-test.sh`, `html.sh` — each script now self-installs its required tool via `uv pip install --quiet` before running, so `make` targets work regardless of venv state

### `contributing.md`
- Getting started section rewritten around `uv` as the recommended setup (`uv sync` + `uv pip install -e ".[dev]"`); note that other environments work too
- Python packages section: `requests` → `httpx`, removed `setuptools`/`wheel`; documented `uv pip install -e ".[dev]"` one-liner
- Coding conventions: deprecated `typing.Dict/List/Tuple` → modern `dict`/`list`/`tuple`
- Added **Linting & formatting** section with `ruff check`, `--fix`, and `ruff format` commands
- Updated file structure diagram to reflect `sync/` and `aio/` subpackages

### `setup.py`
- Version bumped to `3.2.1`

### `uv.lock`
- Regenerated via `uv sync`

### Docs
- Regenerated via `make html`

### `.opencode`
- Added `couchdb3-version-bump` skill

## Verification
- `uv run ruff check .` → 0 errors
- `make test` → 78/78 pass
- `make html` → clean (only pre-existing `MimeTypeEnum` warning)
- `make build` → `couchdb3-3.2.1.tar.gz` and `couchdb3-3.2.1-py3-none-any.whl`