### PR TITLE
feat: add _changes, membership, cluster_setup, and node APIs (v3.3.0)

### DIFF
--- a/.opencode/skills/couchdb3-api-coverage/SKILL.md
+++ b/.opencode/skills/couchdb3-api-coverage/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: couchdb3-api-coverage
+description: Use when implementing or tracking missing CouchDB API endpoint coverage in couchdb3. Documents which endpoints are implemented, which are pending, and the implementation patterns specific to each endpoint group (node-level paths, POST vs GET dispatch for _changes, etc.).
+---
+
+# couchdb3 API Coverage Tracker
+
+## Status legend
+- ✅ Implemented (sync + async)
+- 🔲 Pending
+
+---
+
+## Batch 1 — Server & Database endpoints (v3.3.0)
+
+| Endpoint | Method(s) | Class | Status |
+|---|---|---|---|
+| `GET /{db}/_changes` | `Database.changes()` | Database / AsyncDatabase | ✅ |
+| `POST /{db}/_changes` | `Database.changes(doc_ids=...)` or `changes(selector=...)` | Database / AsyncDatabase | ✅ |
+| `GET /_membership` | `Server.membership()` | Server / AsyncServer | ✅ |
+| `GET /_cluster_setup` | `Server.cluster_setup()` | Server / AsyncServer | ✅ |
+| `POST /_cluster_setup` | `Server.setup_cluster()` | Server / AsyncServer | ✅ |
+| `GET /_node/{node}/_config` | `Server.node_config()` | Server / AsyncServer | ✅ |
+| `GET /_node/{node}/_config/{section}` | `Server.node_config(section=...)` | Server / AsyncServer | ✅ |
+| `GET /_node/{node}/_config/{section}/{key}` | `Server.node_config(section=..., key=...)` | Server / AsyncServer | ✅ |
+| `PUT /_node/{node}/_config/{section}/{key}` | `Server.set_node_config()` | Server / AsyncServer | ✅ |
+| `DELETE /_node/{node}/_config/{section}/{key}` | `Server.delete_node_config()` | Server / AsyncServer | ✅ |
+| `POST /_node/{node}/_config/_reload` | `Server.reload_node_config()` | Server / AsyncServer | ✅ |
+| `GET /_node/{node}/_stats` | `Server.node_stats()` | Server / AsyncServer | ✅ |
+| `GET /_node/{node}/_system` | `Server.node_system()` | Server / AsyncServer | ✅ |
+
+---
+
+## Still pending (from TODO.md)
+
+| Endpoint | Notes |
+|---|---|
+| `DELETE /{db}/_index/{ddoc}/json/{name}` | Delete a Mango index |
+| `GET /{db}/_design_docs` | List design documents |
+| `GET /{db}/_local_docs` / `GET\|PUT\|DELETE /{db}/_local/{docid}` | Local documents |
+| `GET /_membership` | ✅ done in Batch 1 |
+| `POST /_cluster_setup` / `GET /_cluster_setup` | ✅ done in Batch 1 |
+| `GET /_node/{node}/_config`, `_stats`, `_system` | ✅ done in Batch 1 |
+| `GET\|PUT /{db}/_revs_limit` | Revision limit management |
+| `POST /{db}/_missing_revs` / `POST /{db}/_revs_diff` | Replication helpers |
+| `POST /{db}/_view_cleanup` | View index cleanup |
+| `__contains__` on `AsyncServer` | Ergonomic gap — Python disallows async `__contains__` but a helper like `await client.has_db(name)` could fill the gap |
+| `GET /{db}/_changes` with `feed=continuous\|eventsource` | Streaming feeds — deferred; requires iterator/stream response handling |
+
+---
+
+## Implementation patterns
+
+### `Database.changes()` — GET vs POST dispatch
+
+```python
+def changes(self, *, doc_ids=None, selector=None, feed=None, ...):
+    # Validate feed
+    if feed in ("continuous", "eventsource"):
+        raise ValueError(
+            f"feed={feed!r} is not supported; use feed='normal' or feed='longpoll'. "
+            "Streaming feeds require changes_stream() (not yet implemented)."
+        )
+    query_kwargs = {
+        "conflicts": conflicts, "descending": descending, "feed": feed,
+        "filter": filter, "heartbeat": heartbeat, "include_docs": include_docs,
+        ...
+    }
+    if doc_ids is not None:
+        # POST with filter=_doc_ids
+        query_kwargs["filter"] = "_doc_ids"
+        return self._post(
+            resource="_changes",
+            body={"doc_ids": doc_ids},
+            query_kwargs=query_kwargs,
+        ).json()
+    elif selector is not None:
+        # POST with filter=_selector
+        query_kwargs["filter"] = "_selector"
+        return self._post(
+            resource="_changes",
+            body={"selector": selector},
+            query_kwargs=query_kwargs,
+        ).json()
+    else:
+        return self._get(resource="_changes", query_kwargs=query_kwargs).json()
+```
+
+### Node-level path construction
+
+Node API methods live at `/_node/{node}/_config`, `/_stats`, `/_system`. These paths are **not** relative to a database root — they are server-level endpoints.
+
+In `Base._request`, the `root` parameter allows overriding the URL path prefix. Pass `root=None` to use the server root directly:
+
+```python
+def node_config(self, node: str = "_local", section: str | None = None, key: str | None = None):
+    resource = f"_node/{node}/_config"
+    if section:
+        resource = f"{resource}/{section}"
+        if key:
+            resource = f"{resource}/{key}"
+    # Server subclass: self.root is "" so no root override needed
+    return self._get(resource=resource).json()
+```
+
+For `Server` (which has `self.root = ""`), no special root override is needed — the resource path is correct as-is.
+
+### `setup_cluster()` — POST /_cluster_setup (destructive)
+
+**Do not run in integration tests against a production or shared CouchDB instance.**
+Use `@unittest.skip("requires isolated CouchDB cluster — destructive")` on the test.
+
+The action must be one of: `"enable_single_node"`, `"enable_cluster"`, `"add_node"`, `"finish_cluster"`.
+
+### `node_config()` return type
+
+- No `section`, no `key` → returns `dict` (full config tree)
+- `section` only → returns `dict` (section dict)
+- `section` + `key` → returns `str` or primitive (a single JSON value, e.g. `"info"` for log level)
+
+Annotate as `dict | str` to cover all three cases.
+
+---
+
+## Test files
+
+| File | What it covers |
+|---|---|
+| `tests/test_database.py` | `TestDatabase.test_changes_*` (sync) |
+| `tests/test_async_database.py` | `TestAsyncDatabase.test_changes_*` (async) |
+| `tests/test_server.py` | `TestClient.test_membership`, `test_cluster_setup`, `test_node_config_*`, `test_node_stats`, `test_node_system`, `test_reload_node_config` |
+| `tests/test_async_server.py` | Same, all `async def` |
+
+---
+
+## Files modified in Batch 1
+
+| File | Change |
+|---|---|
+| `src/couchdb3/sync/database.py` | Added `Database.changes()` |
+| `src/couchdb3/aio/async_database.py` | Added `AsyncDatabase.changes()` |
+| `src/couchdb3/sync/server.py` | Added `membership`, `cluster_setup`, `setup_cluster`, `node_config`, `set_node_config`, `delete_node_config`, `reload_node_config`, `node_stats`, `node_system` |
+| `src/couchdb3/aio/async_server.py` | Same 9 methods, all `async def` |
+| `tests/test_database.py` | `test_changes_normal`, `test_changes_since`, `test_changes_doc_ids`, `test_changes_include_docs` |
+| `tests/test_async_database.py` | Same 4 tests, async |
+| `tests/test_server.py` | `test_membership`, `test_cluster_setup`, `test_node_config_full`, `test_node_config_section`, `test_node_config_key`, `test_set_and_delete_node_config`, `test_reload_node_config`, `test_node_stats`, `test_node_system`, `test_setup_cluster_skipped` |
+| `tests/test_async_server.py` | Same tests, async |
+| `TODO.md` | Struck through completed items |
+| `pyproject.toml` / `setup.py` | Version bumped to `3.3.0` |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Fetching documents](#fetching-documents)
   - [Views](#views)
   - [Mango queries](#mango-queries)
+  - [Changes feed](#changes-feed)
   - [Working with partitions](#working-with-partitions)
 - [Async client](#async-client)
   - [Connecting to a database server](#connecting-to-a-database-server-1)
@@ -28,6 +29,7 @@
   - [Fetching documents](#fetching-documents-1)
   - [Views](#views-1)
   - [Mango queries](#mango-queries-1)
+  - [Changes feed](#changes-feed-1)
   - [Controlling concurrency](#controlling-concurrency)
   - [Working with async partitions](#working-with-async-partitions)
 
@@ -215,6 +217,46 @@ for doc in result["docs"]:
 plan = db.explain({"type": {"$eq": "post"}}, limit=10)
 ```
 
+### Changes feed
+
+`Database.changes()` wraps `GET /{db}/_changes` (and `POST /{db}/_changes` when filtering by
+document IDs or a Mango selector).
+
+```python
+# All recent changes (normal feed — returns immediately)
+result = db.changes()
+for row in result["results"]:
+    print(row["id"], row["changes"])
+
+# Only changes since a known sequence
+result = db.changes(since="now")  # wait marker — use last_seq to poll later
+last_seq = result["last_seq"]
+result = db.changes(since=last_seq)  # only changes after that point
+
+# Filter to specific document IDs (POST /_changes?filter=_doc_ids)
+result = db.changes(doc_ids=["doc-1", "doc-2"])
+
+# Filter with a Mango selector (POST /_changes?filter=_selector)
+result = db.changes(selector={"type": {"$eq": "post"}})
+
+# Include the full document body in each result
+result = db.changes(include_docs=True)
+for row in result["results"]:
+    print(row["id"], row.get("doc"))
+
+# Long-poll: server holds the connection open until at least one change arrives
+result = db.changes(feed="longpoll", since="now", timeout=30_000)
+```
+
+> **Note — continuous and eventsource feeds**
+>
+> `feed="continuous"` and `feed="eventsource"` are **not supported** by `changes()` and will
+> raise `ValueError`. These modes stream newline-delimited JSON over a persistent HTTP
+> connection, which requires response-body streaming rather than a single buffered read.
+> Support for streaming feeds will be added in a future `changes_stream()` method.
+> For now, a polling loop over `feed="longpoll"` with `since=last_seq` is a practical
+> alternative for most real-time use cases.
+
 ### Working with partitions
 For a partitioned database, the `couchdb3.sync.Partition` class offers a wrapper around partitions (acting similarly
 to collections in Mongo).
@@ -371,6 +413,45 @@ for doc in result["docs"]:
 # 3. Inspect the query plan
 plan = await db.explain({"type": {"$eq": "post"}}, limit=10)
 ```
+
+### Changes feed
+
+`AsyncDatabase.changes()` mirrors the sync API exactly.
+
+```python
+# All recent changes
+result = await db.changes()
+for row in result["results"]:
+    print(row["id"], row["changes"])
+
+# Only changes since a known sequence
+result = await db.changes(since="now")
+last_seq = result["last_seq"]
+result = await db.changes(since=last_seq)
+
+# Filter to specific document IDs (POST /_changes?filter=_doc_ids)
+result = await db.changes(doc_ids=["doc-1", "doc-2"])
+
+# Filter with a Mango selector (POST /_changes?filter=_selector)
+result = await db.changes(selector={"type": {"$eq": "post"}})
+
+# Include the full document body in each result
+result = await db.changes(include_docs=True)
+for row in result["results"]:
+    print(row["id"], row.get("doc"))
+
+# Long-poll: server holds the connection open until at least one change arrives
+result = await db.changes(feed="longpoll", since="now", timeout=30_000)
+```
+
+> **Note — continuous and eventsource feeds**
+>
+> `feed="continuous"` and `feed="eventsource"` are **not supported** by `changes()` and will
+> raise `ValueError`. These modes stream newline-delimited JSON over a persistent HTTP
+> connection, which requires response-body streaming rather than a single buffered read.
+> Support for streaming feeds will be added in a future `changes_stream()` method.
+> For now, a polling loop over `feed="longpoll"` with `since=last_seq` is a practical
+> alternative for most real-time use cases.
 
 ### Controlling concurrency
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ from couchdb3 import Document, ViewResult, ViewRow, exceptions
 ```python
 import couchdb3
 
-client = couchdb3.Server(
-    "http://user:password@127.0.0.1:5984"
-)
+client = couchdb3.Server("http://user:password@127.0.0.1:5984")
 
 # Checking if the server is up
 print(client.up())
@@ -100,7 +98,7 @@ user and password can also be passed into the Server constructor as keyword para
 client = couchdb3.Server(
     "127.0.0.1:5984",  # Scheme omitted - will assume http protocol
     user="user",
-    password="password"
+    password="password",
 )
 ```
 
@@ -123,11 +121,7 @@ print(db)
 
 ### Creating a document
 ```python
-mydoc = {
-    "_id": "mydoc-id",
-    "name": "Hello",
-    "type": "World"
-}
+mydoc = {"_id": "mydoc-id", "name": "Hello", "type": "World"}
 print(db.save(mydoc))
 # ('mydoc-id', True, '1-24fa3b3fd2691da9649dd6abe3cafc7e')
 ```
@@ -139,11 +133,7 @@ To update an existing document, retrieving the revision is paramount.
 In the example below, `dbdoc` contains the key `_rev` and the builtin `dict.update` function is used to update the
 document before saving it.
 ```python
-mydoc = {
-    "_id": "mydoc-id",
-    "name": "Hello World",
-    "type": "Hello World"
-}
+mydoc = {"_id": "mydoc-id", "name": "Hello World", "type": "Hello World"}
 dbdoc = db.get(mydoc["_id"])
 dbdoc.update(mydoc)
 print(db.save(dbdoc))
@@ -155,7 +145,7 @@ mydoc = {
     "_id": "mydoc-id",
     "_rev": db.rev("mydoc-id"),
     "name": "Hello World",
-    "type": "Hello World"
+    "type": "Hello World",
 }
 print(db.save(mydoc))
 # ('mydoc-id', True, '3-d56b14b7ffb87960b51d03269990a30d')
@@ -197,14 +187,13 @@ for item in result:
 ### Views
 ```python
 # 1. Create a design document with a map function
-db.put_design("my-ddoc", views={
-    "my-view": {
-        "map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"
-    }
-})
+db.put_design(
+    "my-ddoc",
+    views={"my-view": {"map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"}},
+)
 
 # 2. Query the view
-result = db.view("my-ddoc", "my-view")                        # ViewResult
+result = db.view("my-ddoc", "my-view")  # ViewResult
 result = db.view("my-ddoc", "my-view", include_docs=True, limit=10)
 
 # 3. Iterate results
@@ -276,10 +265,12 @@ with `async def` methods and `async with` context manager support.
 import asyncio
 from couchdb3.aio import AsyncServer
 
+
 async def main():
     async with AsyncServer("http://user:password@127.0.0.1:5984") as client:
         print(await client.up())
         # True
+
 
 asyncio.run(main())
 ```
@@ -288,11 +279,7 @@ user and password can also be passed as keyword parameters, and the manual lifec
 supported via `await client.aclose()`:
 
 ```python
-client = AsyncServer(
-    "127.0.0.1:5984",
-    user="user",
-    password="password"
-)
+client = AsyncServer("127.0.0.1:5984", user="user", password="password")
 # ... do stuff ...
 await client.aclose()
 ```
@@ -314,11 +301,7 @@ async with AsyncServer("http://user:password@127.0.0.1:5984") as client:
 ```python
 async with AsyncServer("http://user:password@127.0.0.1:5984") as client:
     db = await client.get("mydb")
-    mydoc = {
-        "_id": "mydoc-id",
-        "name": "Hello",
-        "type": "World"
-    }
+    mydoc = {"_id": "mydoc-id", "name": "Hello", "type": "World"}
     print(await db.save(mydoc))
     # ('mydoc-id', True, '1-24fa3b3fd2691da9649dd6abe3cafc7e')
 ```
@@ -329,7 +312,7 @@ mydoc = {
     "_id": "mydoc-id",
     "_rev": await db.rev("mydoc-id"),
     "name": "Hello World",
-    "type": "Hello World"
+    "type": "Hello World",
 }
 print(await db.save(mydoc))
 # ('mydoc-id', True, '2-374aa8f0236b9120242ca64935e2e8f1')
@@ -361,11 +344,10 @@ for item in result:
 ### Views
 ```python
 # 1. Create a design document with a map function
-await db.put_design("my-ddoc", views={
-    "my-view": {
-        "map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"
-    }
-})
+await db.put_design(
+    "my-ddoc",
+    views={"my-view": {"map": "function(doc) { if (doc.type === 'post') emit(doc._id, null); }"}},
+)
 
 # 2. Query the view
 result = await db.view("my-ddoc", "my-view")
@@ -403,9 +385,11 @@ from couchdb3.aio import AsyncServer
 # Limit to 10 concurrent CouchDB operations
 sem = asyncio.Semaphore(10)
 
+
 async def fetch(db, docid):
     async with sem:
         return await db.get(docid)
+
 
 # Optionally tune the underlying connection pool
 client = AsyncServer(
@@ -425,9 +409,11 @@ async with AsyncServer("http://user:password@127.0.0.1:5984") as client:
     partition: AsyncPartition = await db.get_partition("partition_id")
 
     doc_id = "test-id"
-    await partition.save({
-        "_id": doc_id,  # no need to append the partition's ID
-        "type": "example"
-    })
+    await partition.save(
+        {
+            "_id": doc_id,  # no need to append the partition's ID
+            "type": "example",
+        }
+    )
     doc = await partition.get(doc_id)
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -19,14 +19,15 @@
 - Add test for `Database.compact(ddoc=...)` (only no-arg path is tested)
 
 ## Missing API coverage
-- `GET /{db}/_changes` — change feed (polling / longpoll / continuous)
+- <s>`GET /{db}/_changes` — change feed (polling / longpoll / continuous)</s> — `normal` and `longpoll` implemented in v3.3.0; `continuous`/`eventsource` streaming deferred
+- <s>`GET /_membership` — cluster node membership</s> — implemented in v3.3.0
+- <s>`POST /_cluster_setup` / `GET /_cluster_setup` — cluster setup API</s> — implemented in v3.3.0 (`cluster_setup` + `setup_cluster`)
+- <s>`GET /_node/{node}/_config`, `_stats`, `_system` — node-level APIs</s> — implemented in v3.3.0 (`node_config`, `set_node_config`, `delete_node_config`, `reload_node_config`, `node_stats`, `node_system`)
 - `DELETE /{db}/_index/{ddoc}/json/{name}` — delete a Mango index
 - `GET /{db}/_design_docs` — list design documents
 - `GET /{db}/_local_docs` / `GET|PUT|DELETE /{db}/_local/{docid}` — local documents
-- `GET /_membership` — cluster node membership
-- `POST /_cluster_setup` / `GET /_cluster_setup` — cluster setup API
-- `GET /_node/{node}/_config`, `_stats`, `_system` — node-level APIs
 - `GET|PUT /{db}/_revs_limit` — revision limit management
 - `POST /{db}/_missing_revs` / `POST /{db}/_revs_diff` — replication helpers
 - `POST /{db}/_view_cleanup` — view index cleanup
 - `__contains__` on `AsyncServer` (sync `Server` supports `if db in server`; async does not)
+- `GET /{db}/_changes` with `feed=continuous|eventsource` — streaming feeds (deferred)

--- a/TODO.md
+++ b/TODO.md
@@ -31,3 +31,5 @@
 - `POST /{db}/_view_cleanup` — view index cleanup
 - `__contains__` on `AsyncServer` (sync `Server` supports `if db in server`; async does not)
 - `GET /{db}/_changes` with `feed=continuous|eventsource` — streaming feeds (deferred)
+  - **sync:** implement `Database.changes_stream()` as a generator using `httpx.Client.stream()`, yielding parsed JSON objects line-by-line from the NDJSON response; caller controls iteration and closure via a `with` block or explicit `.close()`
+  - **async:** implement `AsyncDatabase.changes_stream()` as an async generator using `httpx.AsyncClient.stream()`, yielding the same parsed objects; caller drives with `async for` and the underlying connection is released on `aclose()` or generator exhaustion

--- a/docs/aio/async_database.html
+++ b/docs/aio/async_database.html
@@ -1117,9 +1117,7 @@ el.replaceWith(d);
                 &#34;in a future release.&#34;
             )
         if doc_ids is not None and selector is not None:
-            raise CouchDBError(
-                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-            )
+            raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
         query_kwargs = {
             &#34;conflicts&#34;: conflicts,
             &#34;descending&#34;: descending,
@@ -1481,9 +1479,7 @@ Default is <code>None</code>.</dd>
             &#34;in a future release.&#34;
         )
     if doc_ids is not None and selector is not None:
-        raise CouchDBError(
-            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-        )
+        raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
     query_kwargs = {
         &#34;conflicts&#34;: conflicts,
         &#34;descending&#34;: descending,

--- a/docs/aio/async_database.html
+++ b/docs/aio/async_database.html
@@ -1018,6 +1018,144 @@ el.replaceWith(d);
             ).json()
         )
 
+    async def changes(
+        self,
+        *,
+        doc_ids: list[str] | None = None,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        feed: str | None = None,
+        filter: str | None = None,
+        heartbeat: int | None = None,
+        include_docs: bool | None = None,
+        attachments: bool | None = None,
+        att_encoding_info: bool | None = None,
+        limit: int | None = None,
+        since: str | None = None,
+        style: str | None = None,
+        timeout: int | None = None,
+        view: str | None = None,
+        seq_interval: int | None = None,
+        selector: dict | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns a sorted list of changes made to documents in the database. Only the most
+        recent change for a given document is included.
+
+        When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+        ``filter=_doc_ids``. When `selector` is provided it is sent as
+        ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+        ``GET /{db}/_changes``.
+
+        .. note::
+            ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+            method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+            addressed in a future ``changes_stream()`` method.
+
+        Parameters
+        ----------
+        doc_ids : list[str]
+            List of document IDs to filter the changes feed. Triggers a POST request with
+            ``filter=_doc_ids``. Mutually exclusive with `selector`.
+        conflicts : bool
+            Include conflicts information. Only effective when `include_docs` is `True`.
+        descending : bool
+            Return changes in descending sequence order. Default `False`.
+        feed : str
+            Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+            ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+        filter : str
+            Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+            ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+            `doc_ids` / `selector` parameters instead.
+        heartbeat : int
+            Milliseconds between heartbeat newlines for ``longpoll`` feed.
+        include_docs : bool
+            Include the associated document with each result. Default `False`.
+        attachments : bool
+            Include Base64-encoded attachment content when `include_docs` is `True`.
+        att_encoding_info : bool
+            Include encoding info in attachment stubs when `include_docs` is `True`.
+        limit : int
+            Maximum number of rows to return.
+        since : str
+            Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+            future changes.
+        style : str
+            Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+        timeout : int
+            Maximum milliseconds to wait for a change (``longpoll`` only).
+        view : str
+            View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+        seq_interval : int
+            Calculate update sequence every N results (reduces server load on large
+            sharded databases).
+        selector : dict
+            Mango selector to filter documents. Triggers a POST request with
+            ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``last_seq`` (`str`) — last change update sequence
+          - ``pending`` (`int`) — count of remaining items in the feed
+          - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+            ``changes``, and optionally ``deleted`` / ``doc``
+
+        Raises
+        ------
+        ValueError
+            If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+        CouchDBError
+            If both `doc_ids` and `selector` are provided.
+        &#34;&#34;&#34;
+        if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+            raise ValueError(
+                f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+                &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+                &#34;in a future release.&#34;
+            )
+        if doc_ids is not None and selector is not None:
+            raise CouchDBError(
+                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+            )
+        query_kwargs = {
+            &#34;conflicts&#34;: conflicts,
+            &#34;descending&#34;: descending,
+            &#34;feed&#34;: feed,
+            &#34;filter&#34;: filter,
+            &#34;heartbeat&#34;: heartbeat,
+            &#34;include_docs&#34;: include_docs,
+            &#34;attachments&#34;: attachments,
+            &#34;att_encoding_info&#34;: att_encoding_info,
+            &#34;limit&#34;: limit,
+            &#34;since&#34;: since,
+            &#34;style&#34;: style,
+            &#34;timeout&#34;: timeout,
+            &#34;view&#34;: view,
+            &#34;seq_interval&#34;: seq_interval,
+        }
+        if doc_ids is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+            return (
+                await self._post(
+                    resource=&#34;_changes&#34;,
+                    body={&#34;doc_ids&#34;: doc_ids},
+                    query_kwargs=query_kwargs,
+                )
+            ).json()
+        if selector is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+            return (
+                await self._post(
+                    resource=&#34;_changes&#34;,
+                    body={&#34;selector&#34;: selector},
+                    query_kwargs=query_kwargs,
+                )
+            ).json()
+        return (await self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs)).json()
+
     async def get_partition(self, partition_id: str) -&gt; AsyncPartition:
         &#34;&#34;&#34;
         Get a given partition.
@@ -1234,6 +1372,222 @@ Default is <code>None</code>.</dd>
 <dl>
 <dt><code>list[dict]</code></dt>
 <dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.async_database.AsyncDatabase.changes"><code class="name flex">
+<span>async def <span class="ident">changes</span></span>(<span>self,<br>*,<br>doc_ids: list[str] | None = None,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>feed: str | None = None,<br>filter: str | None = None,<br>heartbeat: int | None = None,<br>include_docs: bool | None = None,<br>attachments: bool | None = None,<br>att_encoding_info: bool | None = None,<br>limit: int | None = None,<br>since: str | None = None,<br>style: str | None = None,<br>timeout: int | None = None,<br>view: str | None = None,<br>seq_interval: int | None = None,<br>selector: dict | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def changes(
+    self,
+    *,
+    doc_ids: list[str] | None = None,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    feed: str | None = None,
+    filter: str | None = None,
+    heartbeat: int | None = None,
+    include_docs: bool | None = None,
+    attachments: bool | None = None,
+    att_encoding_info: bool | None = None,
+    limit: int | None = None,
+    since: str | None = None,
+    style: str | None = None,
+    timeout: int | None = None,
+    view: str | None = None,
+    seq_interval: int | None = None,
+    selector: dict | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns a sorted list of changes made to documents in the database. Only the most
+    recent change for a given document is included.
+
+    When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+    ``filter=_doc_ids``. When `selector` is provided it is sent as
+    ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+    ``GET /{db}/_changes``.
+
+    .. note::
+        ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+        method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+        addressed in a future ``changes_stream()`` method.
+
+    Parameters
+    ----------
+    doc_ids : list[str]
+        List of document IDs to filter the changes feed. Triggers a POST request with
+        ``filter=_doc_ids``. Mutually exclusive with `selector`.
+    conflicts : bool
+        Include conflicts information. Only effective when `include_docs` is `True`.
+    descending : bool
+        Return changes in descending sequence order. Default `False`.
+    feed : str
+        Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+        ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+    filter : str
+        Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+        ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+        `doc_ids` / `selector` parameters instead.
+    heartbeat : int
+        Milliseconds between heartbeat newlines for ``longpoll`` feed.
+    include_docs : bool
+        Include the associated document with each result. Default `False`.
+    attachments : bool
+        Include Base64-encoded attachment content when `include_docs` is `True`.
+    att_encoding_info : bool
+        Include encoding info in attachment stubs when `include_docs` is `True`.
+    limit : int
+        Maximum number of rows to return.
+    since : str
+        Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+        future changes.
+    style : str
+        Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+    timeout : int
+        Maximum milliseconds to wait for a change (``longpoll`` only).
+    view : str
+        View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+    seq_interval : int
+        Calculate update sequence every N results (reduces server load on large
+        sharded databases).
+    selector : dict
+        Mango selector to filter documents. Triggers a POST request with
+        ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``last_seq`` (`str`) — last change update sequence
+      - ``pending`` (`int`) — count of remaining items in the feed
+      - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+        ``changes``, and optionally ``deleted`` / ``doc``
+
+    Raises
+    ------
+    ValueError
+        If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+    CouchDBError
+        If both `doc_ids` and `selector` are provided.
+    &#34;&#34;&#34;
+    if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+        raise ValueError(
+            f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+            &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+            &#34;in a future release.&#34;
+        )
+    if doc_ids is not None and selector is not None:
+        raise CouchDBError(
+            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+        )
+    query_kwargs = {
+        &#34;conflicts&#34;: conflicts,
+        &#34;descending&#34;: descending,
+        &#34;feed&#34;: feed,
+        &#34;filter&#34;: filter,
+        &#34;heartbeat&#34;: heartbeat,
+        &#34;include_docs&#34;: include_docs,
+        &#34;attachments&#34;: attachments,
+        &#34;att_encoding_info&#34;: att_encoding_info,
+        &#34;limit&#34;: limit,
+        &#34;since&#34;: since,
+        &#34;style&#34;: style,
+        &#34;timeout&#34;: timeout,
+        &#34;view&#34;: view,
+        &#34;seq_interval&#34;: seq_interval,
+    }
+    if doc_ids is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+        return (
+            await self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;doc_ids&#34;: doc_ids},
+                query_kwargs=query_kwargs,
+            )
+        ).json()
+    if selector is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+        return (
+            await self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;selector&#34;: selector},
+                query_kwargs=query_kwargs,
+            )
+        ).json()
+    return (await self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns a sorted list of changes made to documents in the database. Only the most
+recent change for a given document is included.</p>
+<p>When <code>doc_ids</code> is provided the request is sent as <code>POST /{db}/_changes</code> with
+<code>filter=_doc_ids</code>. When <code>selector</code> is provided it is sent as
+<code>POST /{db}/_changes</code> with <code>filter=_selector</code>. All other cases use
+<code>GET /{db}/_changes</code>.</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p><code>feed='continuous'</code> and <code>feed='eventsource'</code> are <strong>not</strong> supported by this
+method. Passing either value raises :class:<code>ValueError</code>. Streaming feeds will be
+addressed in a future <code>changes_stream()</code> method.</p>
+</div>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>doc_ids</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of document IDs to filter the changes feed. Triggers a POST request with
+<code>filter=_doc_ids</code>. Mutually exclusive with <code>selector</code>.</dd>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Only effective when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return changes in descending sequence order. Default <code>False</code>.</dd>
+<dt><strong><code>feed</code></strong> :&ensp;<code>str</code></dt>
+<dd>Feed type. Supported values: <code>'normal'</code> (default), <code>'longpoll'</code>.
+<code>'continuous'</code> and <code>'eventsource'</code> are not supported.</dd>
+<dt><strong><code>filter</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of a filter function (<code>'design_doc/filter_name'</code>, <code>'_design'</code>, or
+<code>'_view'</code>). Do not pass <code>'_doc_ids'</code> or <code>'_selector'</code> manually — use the
+<code>doc_ids</code> / <code>selector</code> parameters instead.</dd>
+<dt><strong><code>heartbeat</code></strong> :&ensp;<code>int</code></dt>
+<dd>Milliseconds between heartbeat newlines for <code>longpoll</code> feed.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each result. Default <code>False</code>.</dd>
+<dt><strong><code>attachments</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include Base64-encoded attachment content when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>att_encoding_info</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include encoding info in attachment stubs when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum number of rows to return.</dd>
+<dt><strong><code>since</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return only changes after the given update sequence. Use <code>'now'</code> to get only
+future changes.</dd>
+<dt><strong><code>style</code></strong> :&ensp;<code>str</code></dt>
+<dd>Revision style. <code>'main_only'</code> (default) or <code>'all_docs'</code>.</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum milliseconds to wait for a change (<code>longpoll</code> only).</dd>
+<dt><strong><code>view</code></strong> :&ensp;<code>str</code></dt>
+<dd>View function to use as a filter (requires <code>filter='_view'</code>).</dd>
+<dt><strong><code>seq_interval</code></strong> :&ensp;<code>int</code></dt>
+<dd>Calculate update sequence every N results (reduces server load on large
+sharded databases).</dd>
+<dt><strong><code>selector</code></strong> :&ensp;<code>dict</code></dt>
+<dd>Mango selector to filter documents. Triggers a POST request with
+<code>filter=_selector</code>. Mutually exclusive with <code>doc_ids</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>last_seq</code> (<code>str</code>) — last change update sequence</li>
+<li><code>pending</code> (<code>int</code>) — count of remaining items in the feed</li>
+<li><code>results</code> (<code>list</code>) — list of change objects, each with <code>id</code>, <code>seq</code>,
+<code>changes</code>, and optionally <code>deleted</code> / <code>doc</code></li>
+</ul>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>feed</code> is <code>'continuous'</code> or <code>'eventsource'</code>.</dd>
+<dt><code>CouchDBError</code></dt>
+<dd>If both <code>doc_ids</code> and <code>selector</code> are provided.</dd>
 </dl></div>
 </dd>
 <dt id="couchdb3.aio.async_database.AsyncDatabase.compact"><code class="name flex">
@@ -3485,6 +3839,7 @@ Default <code>None</code>.</dd>
 <li><code><b><a title="couchdb3.aio.async_database.AsyncDatabase" href="#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></b></code>:
 <ul class="hlist">
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.aclose" href="async_base.html#couchdb3.aio.async_base.AsyncBase.aclose">aclose</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.changes" href="#couchdb3.aio.async_database.AsyncDatabase.changes">changes</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.check" href="async_base.html#couchdb3.aio.async_base.AsyncBase.check">check</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.compact" href="#couchdb3.aio.async_database.AsyncDatabase.compact">compact</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.explain" href="#couchdb3.aio.async_database.AsyncDatabase.explain">explain</a></code></li>
@@ -3522,6 +3877,7 @@ Default <code>None</code>.</dd>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.all_docs" href="#couchdb3.aio.async_database.AsyncDatabase.all_docs">all_docs</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.bulk_docs" href="#couchdb3.aio.async_database.AsyncDatabase.bulk_docs">bulk_docs</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.bulk_get" href="#couchdb3.aio.async_database.AsyncDatabase.bulk_get">bulk_get</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.changes" href="#couchdb3.aio.async_database.AsyncDatabase.changes">changes</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.compact" href="#couchdb3.aio.async_database.AsyncDatabase.compact">compact</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.copy" href="#couchdb3.aio.async_database.AsyncDatabase.copy">copy</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.create" href="#couchdb3.aio.async_database.AsyncDatabase.create">create</a></code></li>

--- a/docs/aio/async_server.html
+++ b/docs/aio/async_server.html
@@ -445,6 +445,269 @@ el.replaceWith(d);
             )
         ).json()
 
+    async def membership(self) -&gt; dict:
+        &#34;&#34;&#34;
+        Displays the nodes that are part of the cluster.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+          - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+        &#34;&#34;&#34;
+        return (await self._get(resource=&#34;_membership&#34;)).json()
+
+    async def cluster_setup(
+        self,
+        *,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns the status of the node or cluster, per the cluster setup wizard.
+
+        Parameters
+        ----------
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist on the node/cluster.
+            Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : A dictionary with a single key ``state`` whose value is one of
+        ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+        ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+        &#34;&#34;&#34;
+        return (
+            await self._get(
+                resource=&#34;_cluster_setup&#34;,
+                query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+            )
+        ).json()
+
+    async def setup_cluster(
+        self,
+        action: str,
+        *,
+        bind_address: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        port: int | None = None,
+        node_count: int | None = None,
+        remote_node: str | None = None,
+        remote_current_user: str | None = None,
+        remote_current_password: str | None = None,
+        host: str | None = None,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Configure a node as a single (standalone) node, as part of a cluster, or finalise
+        a cluster. This is a **destructive** operation — do not run against a shared or
+        production CouchDB instance during testing.
+
+        Parameters
+        ----------
+        action : str
+            One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+            ``&#39;finish_cluster&#39;``.
+        bind_address : str
+            IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+            (``enable_cluster`` and ``enable_single_node`` only)
+        username : str
+            Server-level administrator username to create, or the remote server&#39;s
+            administrator username (``add_node``).
+        password : str
+            Server-level administrator password to create, or the remote server&#39;s password
+            (``add_node``).
+        port : int
+            TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+            remote node&#39;s port (``add_node``).
+        node_count : int
+            Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+            (``enable_cluster`` only)
+        remote_node : str
+            IP address of the remote node. (``enable_cluster`` only)
+        remote_current_user : str
+            Username of the admin on the remote node. (``enable_cluster`` only)
+        remote_current_password : str
+            Password of the admin on the remote node. (``enable_cluster`` only)
+        host : str
+            Remote node IP to add to the cluster. (``add_node`` only)
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist. Defaults to
+            ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : ``{&#34;ok&#34;: true}`` on success.
+        &#34;&#34;&#34;
+        return (
+            await self._post(
+                resource=&#34;_cluster_setup&#34;,
+                body=rm_nones_from_dict(
+                    {
+                        &#34;action&#34;: action,
+                        &#34;bind_address&#34;: bind_address,
+                        &#34;username&#34;: username,
+                        &#34;password&#34;: password,
+                        &#34;port&#34;: port,
+                        &#34;node_count&#34;: node_count,
+                        &#34;remote_node&#34;: remote_node,
+                        &#34;remote_current_user&#34;: remote_current_user,
+                        &#34;remote_current_password&#34;: remote_current_password,
+                        &#34;host&#34;: host,
+                        &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+                    }
+                ),
+            )
+        ).json()
+
+    async def node_config(
+        self,
+        node: str = &#34;_local&#34;,
+        section: str | None = None,
+        key: str | None = None,
+    ) -&gt; dict | str:
+        &#34;&#34;&#34;
+        Returns CouchDB node configuration.
+
+        - No `section` / `key` → full configuration tree (`dict`)
+        - `section` only → configuration section (`dict`)
+        - `section` + `key` → single configuration value (`str` or primitive)
+
+        The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+        section : str
+            Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+        key : str
+            Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+        Returns
+        -------
+        dict | str
+        &#34;&#34;&#34;
+        resource = f&#34;_node/{node}/_config&#34;
+        if section:
+            resource = f&#34;{resource}/{section}&#34;
+            if key:
+                resource = f&#34;{resource}/{key}&#34;
+        return (await self._get(resource=resource)).json()
+
+    async def set_node_config(
+        self,
+        section: str,
+        key: str,
+        value: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Updates a single configuration value on a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        value : str
+            New value (must be a valid JSON string).
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The previous value of the configuration key.
+        &#34;&#34;&#34;
+        return (
+            await self._put(
+                resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+                body=value,
+            )
+        ).json()
+
+    async def delete_node_config(
+        self,
+        section: str,
+        key: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Deletes a single configuration value from a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The deleted value.
+        &#34;&#34;&#34;
+        return (
+            await self._delete(
+                resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+            )
+        ).json()
+
+    async def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Reloads the configuration from disk. Flushes any in-memory configuration changes
+        that have not been written to disk.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        bool : ``True`` on success.
+        &#34;&#34;&#34;
+        return (
+            await self._post(
+                resource=f&#34;_node/{node}/_config/_reload&#34;,
+                body={},
+            )
+        ).json().get(&#34;ok&#34;, False)
+
+    async def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return (await self._get(resource=f&#34;_node/{node}/_stats&#34;)).json()
+
+    async def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns system-level statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return (await self._get(resource=f&#34;_node/{node}/_system&#34;)).json()
+
     async def up(self, raise_exception: bool = False) -&gt; bool:
         &#34;&#34;&#34;
         Check if the server is up.
@@ -638,6 +901,56 @@ instance and performing a <code>check</code> request.</p>
 <h2 id="returns">Returns</h2>
 <p>bool : A boolean indicating if the username/password combination is valid.</p></div>
 </dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.cluster_setup"><code class="name flex">
+<span>async def <span class="ident">cluster_setup</span></span>(<span>self, *, ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def cluster_setup(
+    self,
+    *,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns the status of the node or cluster, per the cluster setup wizard.
+
+    Parameters
+    ----------
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist on the node/cluster.
+        Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : A dictionary with a single key ``state`` whose value is one of
+    ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+    ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+    &#34;&#34;&#34;
+    return (
+        await self._get(
+            resource=&#34;_cluster_setup&#34;,
+            query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Returns the status of the node or cluster, per the cluster setup wizard.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist on the node/cluster.
+Defaults to <code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>dict</code></strong> :&ensp;<code>A dictionary with a single key <code>state</code> whose value is one of</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p><code>'cluster_disabled'</code>, <code>'single_node_disabled'</code>, <code>'single_node_enabled'</code>,
+<code>'cluster_enabled'</code>, or <code>'cluster_finished'</code>.</p></div>
+</dd>
 <dt id="couchdb3.aio.async_server.AsyncServer.create"><code class="name flex">
 <span>async def <span class="ident">create</span></span>(<span>self,<br>name: str,<br>q: int | None = None,<br>n: int | None = None,<br>partitioned: bool = False) ‑> <a title="couchdb3.aio.async_database.AsyncDatabase" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></span>
 </code></dt>
@@ -760,6 +1073,55 @@ instance and performing a <code>check</code> request.</p>
 <h2 id="returns">Returns</h2>
 <p>bool: <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.delete_node_config"><code class="name flex">
+<span>async def <span class="ident">delete_node_config</span></span>(<span>self, section: str, key: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def delete_node_config(
+    self,
+    section: str,
+    key: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Deletes a single configuration value from a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The deleted value.
+    &#34;&#34;&#34;
+    return (
+        await self._delete(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Deletes a single configuration value from a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The deleted value.</p></div>
+</dd>
 <dt id="couchdb3.aio.async_server.AsyncServer.get"><code class="name flex">
 <span>async def <span class="ident">get</span></span>(<span>self, name: str, check: bool = False) ‑> <a title="couchdb3.aio.async_database.AsyncDatabase" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></span>
 </code></dt>
@@ -814,6 +1176,209 @@ instance and performing a <code>check</code> request.</p>
 <dt><code>AsyncDatabase</code></dt>
 <dd>&nbsp;</dd>
 </dl></div>
+</dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.membership"><code class="name flex">
+<span>async def <span class="ident">membership</span></span>(<span>self) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def membership(self) -&gt; dict:
+    &#34;&#34;&#34;
+    Displays the nodes that are part of the cluster.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+      - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+    &#34;&#34;&#34;
+    return (await self._get(resource=&#34;_membership&#34;)).json()</code></pre>
+</details>
+<div class="desc"><p>Displays the nodes that are part of the cluster.</p>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>all_nodes</code> (<code>list[str]</code>) — all nodes this node knows about</li>
+<li><code>cluster_nodes</code> (<code>list[str]</code>) — nodes that are part of the cluster</li>
+</ul></div>
+</dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.node_config"><code class="name flex">
+<span>async def <span class="ident">node_config</span></span>(<span>self, node: str = '_local', section: str | None = None, key: str | None = None) ‑> dict | str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def node_config(
+    self,
+    node: str = &#34;_local&#34;,
+    section: str | None = None,
+    key: str | None = None,
+) -&gt; dict | str:
+    &#34;&#34;&#34;
+    Returns CouchDB node configuration.
+
+    - No `section` / `key` → full configuration tree (`dict`)
+    - `section` only → configuration section (`dict`)
+    - `section` + `key` → single configuration value (`str` or primitive)
+
+    The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+    section : str
+        Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+    key : str
+        Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+    Returns
+    -------
+    dict | str
+    &#34;&#34;&#34;
+    resource = f&#34;_node/{node}/_config&#34;
+    if section:
+        resource = f&#34;{resource}/{section}&#34;
+        if key:
+            resource = f&#34;{resource}/{key}&#34;
+    return (await self._get(resource=resource)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns CouchDB node configuration.</p>
+<ul>
+<li>No <code>section</code> / <code>key</code> → full configuration tree (<code>dict</code>)</li>
+<li><code>section</code> only → configuration section (<code>dict</code>)</li>
+<li><code>section</code> + <code>key</code> → single configuration value (<code>str</code> or primitive)</li>
+</ul>
+<p>The literal string <code>'_local'</code> (default) is an alias for the local node name.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name (e.g. <code>'log'</code>, <code>'couchdb'</code>).</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key within the section (e.g. <code>'level'</code>).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict | str</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.node_stats"><code class="name flex">
+<span>async def <span class="ident">node_stats</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return (await self._get(resource=f&#34;_node/{node}/_stats&#34;)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.node_system"><code class="name flex">
+<span>async def <span class="ident">node_system</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns system-level statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return (await self._get(resource=f&#34;_node/{node}/_system&#34;)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns system-level statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.reload_node_config"><code class="name flex">
+<span>async def <span class="ident">reload_node_config</span></span>(<span>self, node: str = '_local') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Reloads the configuration from disk. Flushes any in-memory configuration changes
+    that have not been written to disk.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    bool : ``True`` on success.
+    &#34;&#34;&#34;
+    return (
+        await self._post(
+            resource=f&#34;_node/{node}/_config/_reload&#34;,
+            body={},
+        )
+    ).json().get(&#34;ok&#34;, False)</code></pre>
+</details>
+<div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
+that have not been written to disk.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> on success.</p></div>
 </dd>
 <dt id="couchdb3.aio.async_server.AsyncServer.replicate"><code class="name flex">
 <span>async def <span class="ident">replicate</span></span>(<span>self,<br>source: dict | str,<br>target: dict | str,<br>replication_id: str | None = None,<br>cancel: bool | None = None,<br>continuous: bool | None = None,<br>create_target: bool | None = None,<br>create_target_params: dict | None = None,<br>doc_ids: list[str] | None = None,<br>filter_func: str | None = None,<br>selector: dict | None = None,<br>source_proxy: str | None = None,<br>target_proxy: str | None = None) ‑> dict</span>
@@ -1049,6 +1614,184 @@ instance and performing a <code>check</code> request.</p>
 <dd>&nbsp;</dd>
 </dl></div>
 </dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.set_node_config"><code class="name flex">
+<span>async def <span class="ident">set_node_config</span></span>(<span>self, section: str, key: str, value: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def set_node_config(
+    self,
+    section: str,
+    key: str,
+    value: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Updates a single configuration value on a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    value : str
+        New value (must be a valid JSON string).
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The previous value of the configuration key.
+    &#34;&#34;&#34;
+    return (
+        await self._put(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+            body=value,
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Updates a single configuration value on a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>str</code></dt>
+<dd>New value (must be a valid JSON string).</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The previous value of the configuration key.</p></div>
+</dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.setup_cluster"><code class="name flex">
+<span>async def <span class="ident">setup_cluster</span></span>(<span>self,<br>action: str,<br>*,<br>bind_address: str | None = None,<br>username: str | None = None,<br>password: str | None = None,<br>port: int | None = None,<br>node_count: int | None = None,<br>remote_node: str | None = None,<br>remote_current_user: str | None = None,<br>remote_current_password: str | None = None,<br>host: str | None = None,<br>ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def setup_cluster(
+    self,
+    action: str,
+    *,
+    bind_address: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    port: int | None = None,
+    node_count: int | None = None,
+    remote_node: str | None = None,
+    remote_current_user: str | None = None,
+    remote_current_password: str | None = None,
+    host: str | None = None,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Configure a node as a single (standalone) node, as part of a cluster, or finalise
+    a cluster. This is a **destructive** operation — do not run against a shared or
+    production CouchDB instance during testing.
+
+    Parameters
+    ----------
+    action : str
+        One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+        ``&#39;finish_cluster&#39;``.
+    bind_address : str
+        IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+        (``enable_cluster`` and ``enable_single_node`` only)
+    username : str
+        Server-level administrator username to create, or the remote server&#39;s
+        administrator username (``add_node``).
+    password : str
+        Server-level administrator password to create, or the remote server&#39;s password
+        (``add_node``).
+    port : int
+        TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+        remote node&#39;s port (``add_node``).
+    node_count : int
+        Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+        (``enable_cluster`` only)
+    remote_node : str
+        IP address of the remote node. (``enable_cluster`` only)
+    remote_current_user : str
+        Username of the admin on the remote node. (``enable_cluster`` only)
+    remote_current_password : str
+        Password of the admin on the remote node. (``enable_cluster`` only)
+    host : str
+        Remote node IP to add to the cluster. (``add_node`` only)
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist. Defaults to
+        ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : ``{&#34;ok&#34;: true}`` on success.
+    &#34;&#34;&#34;
+    return (
+        await self._post(
+            resource=&#34;_cluster_setup&#34;,
+            body=rm_nones_from_dict(
+                {
+                    &#34;action&#34;: action,
+                    &#34;bind_address&#34;: bind_address,
+                    &#34;username&#34;: username,
+                    &#34;password&#34;: password,
+                    &#34;port&#34;: port,
+                    &#34;node_count&#34;: node_count,
+                    &#34;remote_node&#34;: remote_node,
+                    &#34;remote_current_user&#34;: remote_current_user,
+                    &#34;remote_current_password&#34;: remote_current_password,
+                    &#34;host&#34;: host,
+                    &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+                }
+            ),
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Configure a node as a single (standalone) node, as part of a cluster, or finalise
+a cluster. This is a <strong>destructive</strong> operation — do not run against a shared or
+production CouchDB instance during testing.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>action</code></strong> :&ensp;<code>str</code></dt>
+<dd>One of <code>'enable_single_node'</code>, <code>'enable_cluster'</code>, <code>'add_node'</code>, or
+<code>'finish_cluster'</code>.</dd>
+<dt><strong><code>bind_address</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address to bind the current node. Use <code>'0.0.0.0'</code> to bind all interfaces.
+(<code>enable_cluster</code> and <code>enable_single_node</code> only)</dd>
+<dt><strong><code>username</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator username to create, or the remote server's
+administrator username (<code>add_node</code>).</dd>
+<dt><strong><code>password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator password to create, or the remote server's password
+(<code>add_node</code>).</dd>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>TCP port for this node (<code>enable_cluster</code> / <code>enable_single_node</code>) or the
+remote node's port (<code>add_node</code>).</dd>
+<dt><strong><code>node_count</code></strong> :&ensp;<code>int</code></dt>
+<dd>Total number of nodes to join into the cluster. Determines <code>n</code> (max 3).
+(<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_node</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address of the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_user</code></strong> :&ensp;<code>str</code></dt>
+<dd>Username of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Password of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>host</code></strong> :&ensp;<code>str</code></dt>
+<dd>Remote node IP to add to the cluster. (<code>add_node</code> only)</dd>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist. Defaults to
+<code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : <code>{"ok": true}</code> on success.</p></div>
+</dd>
 <dt id="couchdb3.aio.async_server.AsyncServer.up"><code class="name flex">
 <span>async def <span class="ident">up</span></span>(<span>self, raise_exception: bool = False) ‑> bool</span>
 </code></dt>
@@ -1122,12 +1865,21 @@ instance and performing a <code>check</code> request.</p>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.active_tasks" href="#couchdb3.aio.async_server.AsyncServer.active_tasks">active_tasks</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.all_dbs" href="#couchdb3.aio.async_server.AsyncServer.all_dbs">all_dbs</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.check_user" href="#couchdb3.aio.async_server.AsyncServer.check_user">check_user</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.cluster_setup" href="#couchdb3.aio.async_server.AsyncServer.cluster_setup">cluster_setup</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.create" href="#couchdb3.aio.async_server.AsyncServer.create">create</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.dbs_info" href="#couchdb3.aio.async_server.AsyncServer.dbs_info">dbs_info</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.delete" href="#couchdb3.aio.async_server.AsyncServer.delete">delete</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.delete_node_config" href="#couchdb3.aio.async_server.AsyncServer.delete_node_config">delete_node_config</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.get" href="#couchdb3.aio.async_server.AsyncServer.get">get</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.membership" href="#couchdb3.aio.async_server.AsyncServer.membership">membership</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.node_config" href="#couchdb3.aio.async_server.AsyncServer.node_config">node_config</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.node_stats" href="#couchdb3.aio.async_server.AsyncServer.node_stats">node_stats</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.node_system" href="#couchdb3.aio.async_server.AsyncServer.node_system">node_system</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.reload_node_config" href="#couchdb3.aio.async_server.AsyncServer.reload_node_config">reload_node_config</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.replicate" href="#couchdb3.aio.async_server.AsyncServer.replicate">replicate</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.save_user" href="#couchdb3.aio.async_server.AsyncServer.save_user">save_user</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.set_node_config" href="#couchdb3.aio.async_server.AsyncServer.set_node_config">set_node_config</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.setup_cluster" href="#couchdb3.aio.async_server.AsyncServer.setup_cluster">setup_cluster</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.up" href="#couchdb3.aio.async_server.AsyncServer.up">up</a></code></li>
 </ul>
 </li>

--- a/docs/aio/async_server.html
+++ b/docs/aio/async_server.html
@@ -672,11 +672,15 @@ el.replaceWith(d);
         bool : ``True`` on success.
         &#34;&#34;&#34;
         return (
-            await self._post(
-                resource=f&#34;_node/{node}/_config/_reload&#34;,
-                body={},
+            (
+                await self._post(
+                    resource=f&#34;_node/{node}/_config/_reload&#34;,
+                    body={},
+                )
             )
-        ).json().get(&#34;ok&#34;, False)
+            .json()
+            .get(&#34;ok&#34;, False)
+        )
 
     async def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
         &#34;&#34;&#34;
@@ -1364,11 +1368,15 @@ Defaults to <code>["_users", "_replicator"]</code>.</dd>
     bool : ``True`` on success.
     &#34;&#34;&#34;
     return (
-        await self._post(
-            resource=f&#34;_node/{node}/_config/_reload&#34;,
-            body={},
+        (
+            await self._post(
+                resource=f&#34;_node/{node}/_config/_reload&#34;,
+                body={},
+            )
         )
-    ).json().get(&#34;ok&#34;, False)</code></pre>
+        .json()
+        .get(&#34;ok&#34;, False)
+    )</code></pre>
 </details>
 <div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
 that have not been written to disk.</p>

--- a/docs/aio/index.html
+++ b/docs/aio/index.html
@@ -1137,9 +1137,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
                 &#34;in a future release.&#34;
             )
         if doc_ids is not None and selector is not None:
-            raise CouchDBError(
-                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-            )
+            raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
         query_kwargs = {
             &#34;conflicts&#34;: conflicts,
             &#34;descending&#34;: descending,
@@ -1501,9 +1499,7 @@ Default is <code>None</code>.</dd>
             &#34;in a future release.&#34;
         )
     if doc_ids is not None and selector is not None:
-        raise CouchDBError(
-            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-        )
+        raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
     query_kwargs = {
         &#34;conflicts&#34;: conflicts,
         &#34;descending&#34;: descending,
@@ -4502,11 +4498,15 @@ Default <code>None</code>.</dd>
         bool : ``True`` on success.
         &#34;&#34;&#34;
         return (
-            await self._post(
-                resource=f&#34;_node/{node}/_config/_reload&#34;,
-                body={},
+            (
+                await self._post(
+                    resource=f&#34;_node/{node}/_config/_reload&#34;,
+                    body={},
+                )
             )
-        ).json().get(&#34;ok&#34;, False)
+            .json()
+            .get(&#34;ok&#34;, False)
+        )
 
     async def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
         &#34;&#34;&#34;
@@ -5194,11 +5194,15 @@ Defaults to <code>["_users", "_replicator"]</code>.</dd>
     bool : ``True`` on success.
     &#34;&#34;&#34;
     return (
-        await self._post(
-            resource=f&#34;_node/{node}/_config/_reload&#34;,
-            body={},
+        (
+            await self._post(
+                resource=f&#34;_node/{node}/_config/_reload&#34;,
+                body={},
+            )
         )
-    ).json().get(&#34;ok&#34;, False)</code></pre>
+        .json()
+        .get(&#34;ok&#34;, False)
+    )</code></pre>
 </details>
 <div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
 that have not been written to disk.</p>

--- a/docs/aio/index.html
+++ b/docs/aio/index.html
@@ -1038,6 +1038,144 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             ).json()
         )
 
+    async def changes(
+        self,
+        *,
+        doc_ids: list[str] | None = None,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        feed: str | None = None,
+        filter: str | None = None,
+        heartbeat: int | None = None,
+        include_docs: bool | None = None,
+        attachments: bool | None = None,
+        att_encoding_info: bool | None = None,
+        limit: int | None = None,
+        since: str | None = None,
+        style: str | None = None,
+        timeout: int | None = None,
+        view: str | None = None,
+        seq_interval: int | None = None,
+        selector: dict | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns a sorted list of changes made to documents in the database. Only the most
+        recent change for a given document is included.
+
+        When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+        ``filter=_doc_ids``. When `selector` is provided it is sent as
+        ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+        ``GET /{db}/_changes``.
+
+        .. note::
+            ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+            method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+            addressed in a future ``changes_stream()`` method.
+
+        Parameters
+        ----------
+        doc_ids : list[str]
+            List of document IDs to filter the changes feed. Triggers a POST request with
+            ``filter=_doc_ids``. Mutually exclusive with `selector`.
+        conflicts : bool
+            Include conflicts information. Only effective when `include_docs` is `True`.
+        descending : bool
+            Return changes in descending sequence order. Default `False`.
+        feed : str
+            Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+            ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+        filter : str
+            Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+            ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+            `doc_ids` / `selector` parameters instead.
+        heartbeat : int
+            Milliseconds between heartbeat newlines for ``longpoll`` feed.
+        include_docs : bool
+            Include the associated document with each result. Default `False`.
+        attachments : bool
+            Include Base64-encoded attachment content when `include_docs` is `True`.
+        att_encoding_info : bool
+            Include encoding info in attachment stubs when `include_docs` is `True`.
+        limit : int
+            Maximum number of rows to return.
+        since : str
+            Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+            future changes.
+        style : str
+            Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+        timeout : int
+            Maximum milliseconds to wait for a change (``longpoll`` only).
+        view : str
+            View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+        seq_interval : int
+            Calculate update sequence every N results (reduces server load on large
+            sharded databases).
+        selector : dict
+            Mango selector to filter documents. Triggers a POST request with
+            ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``last_seq`` (`str`) — last change update sequence
+          - ``pending`` (`int`) — count of remaining items in the feed
+          - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+            ``changes``, and optionally ``deleted`` / ``doc``
+
+        Raises
+        ------
+        ValueError
+            If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+        CouchDBError
+            If both `doc_ids` and `selector` are provided.
+        &#34;&#34;&#34;
+        if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+            raise ValueError(
+                f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+                &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+                &#34;in a future release.&#34;
+            )
+        if doc_ids is not None and selector is not None:
+            raise CouchDBError(
+                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+            )
+        query_kwargs = {
+            &#34;conflicts&#34;: conflicts,
+            &#34;descending&#34;: descending,
+            &#34;feed&#34;: feed,
+            &#34;filter&#34;: filter,
+            &#34;heartbeat&#34;: heartbeat,
+            &#34;include_docs&#34;: include_docs,
+            &#34;attachments&#34;: attachments,
+            &#34;att_encoding_info&#34;: att_encoding_info,
+            &#34;limit&#34;: limit,
+            &#34;since&#34;: since,
+            &#34;style&#34;: style,
+            &#34;timeout&#34;: timeout,
+            &#34;view&#34;: view,
+            &#34;seq_interval&#34;: seq_interval,
+        }
+        if doc_ids is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+            return (
+                await self._post(
+                    resource=&#34;_changes&#34;,
+                    body={&#34;doc_ids&#34;: doc_ids},
+                    query_kwargs=query_kwargs,
+                )
+            ).json()
+        if selector is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+            return (
+                await self._post(
+                    resource=&#34;_changes&#34;,
+                    body={&#34;selector&#34;: selector},
+                    query_kwargs=query_kwargs,
+                )
+            ).json()
+        return (await self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs)).json()
+
     async def get_partition(self, partition_id: str) -&gt; AsyncPartition:
         &#34;&#34;&#34;
         Get a given partition.
@@ -1254,6 +1392,222 @@ Default is <code>None</code>.</dd>
 <dl>
 <dt><code>list[dict]</code></dt>
 <dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.AsyncDatabase.changes"><code class="name flex">
+<span>async def <span class="ident">changes</span></span>(<span>self,<br>*,<br>doc_ids: list[str] | None = None,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>feed: str | None = None,<br>filter: str | None = None,<br>heartbeat: int | None = None,<br>include_docs: bool | None = None,<br>attachments: bool | None = None,<br>att_encoding_info: bool | None = None,<br>limit: int | None = None,<br>since: str | None = None,<br>style: str | None = None,<br>timeout: int | None = None,<br>view: str | None = None,<br>seq_interval: int | None = None,<br>selector: dict | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def changes(
+    self,
+    *,
+    doc_ids: list[str] | None = None,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    feed: str | None = None,
+    filter: str | None = None,
+    heartbeat: int | None = None,
+    include_docs: bool | None = None,
+    attachments: bool | None = None,
+    att_encoding_info: bool | None = None,
+    limit: int | None = None,
+    since: str | None = None,
+    style: str | None = None,
+    timeout: int | None = None,
+    view: str | None = None,
+    seq_interval: int | None = None,
+    selector: dict | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns a sorted list of changes made to documents in the database. Only the most
+    recent change for a given document is included.
+
+    When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+    ``filter=_doc_ids``. When `selector` is provided it is sent as
+    ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+    ``GET /{db}/_changes``.
+
+    .. note::
+        ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+        method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+        addressed in a future ``changes_stream()`` method.
+
+    Parameters
+    ----------
+    doc_ids : list[str]
+        List of document IDs to filter the changes feed. Triggers a POST request with
+        ``filter=_doc_ids``. Mutually exclusive with `selector`.
+    conflicts : bool
+        Include conflicts information. Only effective when `include_docs` is `True`.
+    descending : bool
+        Return changes in descending sequence order. Default `False`.
+    feed : str
+        Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+        ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+    filter : str
+        Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+        ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+        `doc_ids` / `selector` parameters instead.
+    heartbeat : int
+        Milliseconds between heartbeat newlines for ``longpoll`` feed.
+    include_docs : bool
+        Include the associated document with each result. Default `False`.
+    attachments : bool
+        Include Base64-encoded attachment content when `include_docs` is `True`.
+    att_encoding_info : bool
+        Include encoding info in attachment stubs when `include_docs` is `True`.
+    limit : int
+        Maximum number of rows to return.
+    since : str
+        Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+        future changes.
+    style : str
+        Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+    timeout : int
+        Maximum milliseconds to wait for a change (``longpoll`` only).
+    view : str
+        View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+    seq_interval : int
+        Calculate update sequence every N results (reduces server load on large
+        sharded databases).
+    selector : dict
+        Mango selector to filter documents. Triggers a POST request with
+        ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``last_seq`` (`str`) — last change update sequence
+      - ``pending`` (`int`) — count of remaining items in the feed
+      - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+        ``changes``, and optionally ``deleted`` / ``doc``
+
+    Raises
+    ------
+    ValueError
+        If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+    CouchDBError
+        If both `doc_ids` and `selector` are provided.
+    &#34;&#34;&#34;
+    if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+        raise ValueError(
+            f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+            &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+            &#34;in a future release.&#34;
+        )
+    if doc_ids is not None and selector is not None:
+        raise CouchDBError(
+            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+        )
+    query_kwargs = {
+        &#34;conflicts&#34;: conflicts,
+        &#34;descending&#34;: descending,
+        &#34;feed&#34;: feed,
+        &#34;filter&#34;: filter,
+        &#34;heartbeat&#34;: heartbeat,
+        &#34;include_docs&#34;: include_docs,
+        &#34;attachments&#34;: attachments,
+        &#34;att_encoding_info&#34;: att_encoding_info,
+        &#34;limit&#34;: limit,
+        &#34;since&#34;: since,
+        &#34;style&#34;: style,
+        &#34;timeout&#34;: timeout,
+        &#34;view&#34;: view,
+        &#34;seq_interval&#34;: seq_interval,
+    }
+    if doc_ids is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+        return (
+            await self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;doc_ids&#34;: doc_ids},
+                query_kwargs=query_kwargs,
+            )
+        ).json()
+    if selector is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+        return (
+            await self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;selector&#34;: selector},
+                query_kwargs=query_kwargs,
+            )
+        ).json()
+    return (await self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns a sorted list of changes made to documents in the database. Only the most
+recent change for a given document is included.</p>
+<p>When <code>doc_ids</code> is provided the request is sent as <code>POST /{db}/_changes</code> with
+<code>filter=_doc_ids</code>. When <code>selector</code> is provided it is sent as
+<code>POST /{db}/_changes</code> with <code>filter=_selector</code>. All other cases use
+<code>GET /{db}/_changes</code>.</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p><code>feed='continuous'</code> and <code>feed='eventsource'</code> are <strong>not</strong> supported by this
+method. Passing either value raises :class:<code>ValueError</code>. Streaming feeds will be
+addressed in a future <code>changes_stream()</code> method.</p>
+</div>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>doc_ids</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of document IDs to filter the changes feed. Triggers a POST request with
+<code>filter=_doc_ids</code>. Mutually exclusive with <code>selector</code>.</dd>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Only effective when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return changes in descending sequence order. Default <code>False</code>.</dd>
+<dt><strong><code>feed</code></strong> :&ensp;<code>str</code></dt>
+<dd>Feed type. Supported values: <code>'normal'</code> (default), <code>'longpoll'</code>.
+<code>'continuous'</code> and <code>'eventsource'</code> are not supported.</dd>
+<dt><strong><code>filter</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of a filter function (<code>'design_doc/filter_name'</code>, <code>'_design'</code>, or
+<code>'_view'</code>). Do not pass <code>'_doc_ids'</code> or <code>'_selector'</code> manually — use the
+<code>doc_ids</code> / <code>selector</code> parameters instead.</dd>
+<dt><strong><code>heartbeat</code></strong> :&ensp;<code>int</code></dt>
+<dd>Milliseconds between heartbeat newlines for <code>longpoll</code> feed.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each result. Default <code>False</code>.</dd>
+<dt><strong><code>attachments</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include Base64-encoded attachment content when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>att_encoding_info</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include encoding info in attachment stubs when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum number of rows to return.</dd>
+<dt><strong><code>since</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return only changes after the given update sequence. Use <code>'now'</code> to get only
+future changes.</dd>
+<dt><strong><code>style</code></strong> :&ensp;<code>str</code></dt>
+<dd>Revision style. <code>'main_only'</code> (default) or <code>'all_docs'</code>.</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum milliseconds to wait for a change (<code>longpoll</code> only).</dd>
+<dt><strong><code>view</code></strong> :&ensp;<code>str</code></dt>
+<dd>View function to use as a filter (requires <code>filter='_view'</code>).</dd>
+<dt><strong><code>seq_interval</code></strong> :&ensp;<code>int</code></dt>
+<dd>Calculate update sequence every N results (reduces server load on large
+sharded databases).</dd>
+<dt><strong><code>selector</code></strong> :&ensp;<code>dict</code></dt>
+<dd>Mango selector to filter documents. Triggers a POST request with
+<code>filter=_selector</code>. Mutually exclusive with <code>doc_ids</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>last_seq</code> (<code>str</code>) — last change update sequence</li>
+<li><code>pending</code> (<code>int</code>) — count of remaining items in the feed</li>
+<li><code>results</code> (<code>list</code>) — list of change objects, each with <code>id</code>, <code>seq</code>,
+<code>changes</code>, and optionally <code>deleted</code> / <code>doc</code></li>
+</ul>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>feed</code> is <code>'continuous'</code> or <code>'eventsource'</code>.</dd>
+<dt><code>CouchDBError</code></dt>
+<dd>If both <code>doc_ids</code> and <code>selector</code> are provided.</dd>
 </dl></div>
 </dd>
 <dt id="couchdb3.aio.AsyncDatabase.compact"><code class="name flex">
@@ -3505,6 +3859,7 @@ Default <code>None</code>.</dd>
 <li><code><b><a title="couchdb3.aio.async_database.AsyncDatabase" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></b></code>:
 <ul class="hlist">
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.aclose" href="async_base.html#couchdb3.aio.async_base.AsyncBase.aclose">aclose</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.changes" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.changes">changes</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.check" href="async_base.html#couchdb3.aio.async_base.AsyncBase.check">check</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.compact" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.compact">compact</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.explain" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.explain">explain</a></code></li>
@@ -3920,6 +4275,269 @@ Default <code>None</code>.</dd>
             )
         ).json()
 
+    async def membership(self) -&gt; dict:
+        &#34;&#34;&#34;
+        Displays the nodes that are part of the cluster.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+          - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+        &#34;&#34;&#34;
+        return (await self._get(resource=&#34;_membership&#34;)).json()
+
+    async def cluster_setup(
+        self,
+        *,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns the status of the node or cluster, per the cluster setup wizard.
+
+        Parameters
+        ----------
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist on the node/cluster.
+            Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : A dictionary with a single key ``state`` whose value is one of
+        ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+        ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+        &#34;&#34;&#34;
+        return (
+            await self._get(
+                resource=&#34;_cluster_setup&#34;,
+                query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+            )
+        ).json()
+
+    async def setup_cluster(
+        self,
+        action: str,
+        *,
+        bind_address: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        port: int | None = None,
+        node_count: int | None = None,
+        remote_node: str | None = None,
+        remote_current_user: str | None = None,
+        remote_current_password: str | None = None,
+        host: str | None = None,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Configure a node as a single (standalone) node, as part of a cluster, or finalise
+        a cluster. This is a **destructive** operation — do not run against a shared or
+        production CouchDB instance during testing.
+
+        Parameters
+        ----------
+        action : str
+            One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+            ``&#39;finish_cluster&#39;``.
+        bind_address : str
+            IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+            (``enable_cluster`` and ``enable_single_node`` only)
+        username : str
+            Server-level administrator username to create, or the remote server&#39;s
+            administrator username (``add_node``).
+        password : str
+            Server-level administrator password to create, or the remote server&#39;s password
+            (``add_node``).
+        port : int
+            TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+            remote node&#39;s port (``add_node``).
+        node_count : int
+            Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+            (``enable_cluster`` only)
+        remote_node : str
+            IP address of the remote node. (``enable_cluster`` only)
+        remote_current_user : str
+            Username of the admin on the remote node. (``enable_cluster`` only)
+        remote_current_password : str
+            Password of the admin on the remote node. (``enable_cluster`` only)
+        host : str
+            Remote node IP to add to the cluster. (``add_node`` only)
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist. Defaults to
+            ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : ``{&#34;ok&#34;: true}`` on success.
+        &#34;&#34;&#34;
+        return (
+            await self._post(
+                resource=&#34;_cluster_setup&#34;,
+                body=rm_nones_from_dict(
+                    {
+                        &#34;action&#34;: action,
+                        &#34;bind_address&#34;: bind_address,
+                        &#34;username&#34;: username,
+                        &#34;password&#34;: password,
+                        &#34;port&#34;: port,
+                        &#34;node_count&#34;: node_count,
+                        &#34;remote_node&#34;: remote_node,
+                        &#34;remote_current_user&#34;: remote_current_user,
+                        &#34;remote_current_password&#34;: remote_current_password,
+                        &#34;host&#34;: host,
+                        &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+                    }
+                ),
+            )
+        ).json()
+
+    async def node_config(
+        self,
+        node: str = &#34;_local&#34;,
+        section: str | None = None,
+        key: str | None = None,
+    ) -&gt; dict | str:
+        &#34;&#34;&#34;
+        Returns CouchDB node configuration.
+
+        - No `section` / `key` → full configuration tree (`dict`)
+        - `section` only → configuration section (`dict`)
+        - `section` + `key` → single configuration value (`str` or primitive)
+
+        The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+        section : str
+            Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+        key : str
+            Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+        Returns
+        -------
+        dict | str
+        &#34;&#34;&#34;
+        resource = f&#34;_node/{node}/_config&#34;
+        if section:
+            resource = f&#34;{resource}/{section}&#34;
+            if key:
+                resource = f&#34;{resource}/{key}&#34;
+        return (await self._get(resource=resource)).json()
+
+    async def set_node_config(
+        self,
+        section: str,
+        key: str,
+        value: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Updates a single configuration value on a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        value : str
+            New value (must be a valid JSON string).
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The previous value of the configuration key.
+        &#34;&#34;&#34;
+        return (
+            await self._put(
+                resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+                body=value,
+            )
+        ).json()
+
+    async def delete_node_config(
+        self,
+        section: str,
+        key: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Deletes a single configuration value from a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The deleted value.
+        &#34;&#34;&#34;
+        return (
+            await self._delete(
+                resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+            )
+        ).json()
+
+    async def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Reloads the configuration from disk. Flushes any in-memory configuration changes
+        that have not been written to disk.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        bool : ``True`` on success.
+        &#34;&#34;&#34;
+        return (
+            await self._post(
+                resource=f&#34;_node/{node}/_config/_reload&#34;,
+                body={},
+            )
+        ).json().get(&#34;ok&#34;, False)
+
+    async def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return (await self._get(resource=f&#34;_node/{node}/_stats&#34;)).json()
+
+    async def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns system-level statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return (await self._get(resource=f&#34;_node/{node}/_system&#34;)).json()
+
     async def up(self, raise_exception: bool = False) -&gt; bool:
         &#34;&#34;&#34;
         Check if the server is up.
@@ -4113,6 +4731,56 @@ instance and performing a <code>check</code> request.</p>
 <h2 id="returns">Returns</h2>
 <p>bool : A boolean indicating if the username/password combination is valid.</p></div>
 </dd>
+<dt id="couchdb3.aio.AsyncServer.cluster_setup"><code class="name flex">
+<span>async def <span class="ident">cluster_setup</span></span>(<span>self, *, ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def cluster_setup(
+    self,
+    *,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns the status of the node or cluster, per the cluster setup wizard.
+
+    Parameters
+    ----------
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist on the node/cluster.
+        Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : A dictionary with a single key ``state`` whose value is one of
+    ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+    ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+    &#34;&#34;&#34;
+    return (
+        await self._get(
+            resource=&#34;_cluster_setup&#34;,
+            query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Returns the status of the node or cluster, per the cluster setup wizard.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist on the node/cluster.
+Defaults to <code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>dict</code></strong> :&ensp;<code>A dictionary with a single key <code>state</code> whose value is one of</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p><code>'cluster_disabled'</code>, <code>'single_node_disabled'</code>, <code>'single_node_enabled'</code>,
+<code>'cluster_enabled'</code>, or <code>'cluster_finished'</code>.</p></div>
+</dd>
 <dt id="couchdb3.aio.AsyncServer.create"><code class="name flex">
 <span>async def <span class="ident">create</span></span>(<span>self,<br>name: str,<br>q: int | None = None,<br>n: int | None = None,<br>partitioned: bool = False) ‑> <a title="couchdb3.aio.async_database.AsyncDatabase" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></span>
 </code></dt>
@@ -4235,6 +4903,55 @@ instance and performing a <code>check</code> request.</p>
 <h2 id="returns">Returns</h2>
 <p>bool: <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.aio.AsyncServer.delete_node_config"><code class="name flex">
+<span>async def <span class="ident">delete_node_config</span></span>(<span>self, section: str, key: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def delete_node_config(
+    self,
+    section: str,
+    key: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Deletes a single configuration value from a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The deleted value.
+    &#34;&#34;&#34;
+    return (
+        await self._delete(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Deletes a single configuration value from a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The deleted value.</p></div>
+</dd>
 <dt id="couchdb3.aio.AsyncServer.get"><code class="name flex">
 <span>async def <span class="ident">get</span></span>(<span>self, name: str, check: bool = False) ‑> <a title="couchdb3.aio.async_database.AsyncDatabase" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></span>
 </code></dt>
@@ -4289,6 +5006,209 @@ instance and performing a <code>check</code> request.</p>
 <dt><code><a title="couchdb3.aio.AsyncDatabase" href="#couchdb3.aio.AsyncDatabase">AsyncDatabase</a></code></dt>
 <dd>&nbsp;</dd>
 </dl></div>
+</dd>
+<dt id="couchdb3.aio.AsyncServer.membership"><code class="name flex">
+<span>async def <span class="ident">membership</span></span>(<span>self) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def membership(self) -&gt; dict:
+    &#34;&#34;&#34;
+    Displays the nodes that are part of the cluster.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+      - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+    &#34;&#34;&#34;
+    return (await self._get(resource=&#34;_membership&#34;)).json()</code></pre>
+</details>
+<div class="desc"><p>Displays the nodes that are part of the cluster.</p>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>all_nodes</code> (<code>list[str]</code>) — all nodes this node knows about</li>
+<li><code>cluster_nodes</code> (<code>list[str]</code>) — nodes that are part of the cluster</li>
+</ul></div>
+</dd>
+<dt id="couchdb3.aio.AsyncServer.node_config"><code class="name flex">
+<span>async def <span class="ident">node_config</span></span>(<span>self, node: str = '_local', section: str | None = None, key: str | None = None) ‑> dict | str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def node_config(
+    self,
+    node: str = &#34;_local&#34;,
+    section: str | None = None,
+    key: str | None = None,
+) -&gt; dict | str:
+    &#34;&#34;&#34;
+    Returns CouchDB node configuration.
+
+    - No `section` / `key` → full configuration tree (`dict`)
+    - `section` only → configuration section (`dict`)
+    - `section` + `key` → single configuration value (`str` or primitive)
+
+    The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+    section : str
+        Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+    key : str
+        Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+    Returns
+    -------
+    dict | str
+    &#34;&#34;&#34;
+    resource = f&#34;_node/{node}/_config&#34;
+    if section:
+        resource = f&#34;{resource}/{section}&#34;
+        if key:
+            resource = f&#34;{resource}/{key}&#34;
+    return (await self._get(resource=resource)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns CouchDB node configuration.</p>
+<ul>
+<li>No <code>section</code> / <code>key</code> → full configuration tree (<code>dict</code>)</li>
+<li><code>section</code> only → configuration section (<code>dict</code>)</li>
+<li><code>section</code> + <code>key</code> → single configuration value (<code>str</code> or primitive)</li>
+</ul>
+<p>The literal string <code>'_local'</code> (default) is an alias for the local node name.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name (e.g. <code>'log'</code>, <code>'couchdb'</code>).</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key within the section (e.g. <code>'level'</code>).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict | str</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.AsyncServer.node_stats"><code class="name flex">
+<span>async def <span class="ident">node_stats</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return (await self._get(resource=f&#34;_node/{node}/_stats&#34;)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.AsyncServer.node_system"><code class="name flex">
+<span>async def <span class="ident">node_system</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns system-level statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return (await self._get(resource=f&#34;_node/{node}/_system&#34;)).json()</code></pre>
+</details>
+<div class="desc"><p>Returns system-level statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.aio.AsyncServer.reload_node_config"><code class="name flex">
+<span>async def <span class="ident">reload_node_config</span></span>(<span>self, node: str = '_local') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Reloads the configuration from disk. Flushes any in-memory configuration changes
+    that have not been written to disk.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    bool : ``True`` on success.
+    &#34;&#34;&#34;
+    return (
+        await self._post(
+            resource=f&#34;_node/{node}/_config/_reload&#34;,
+            body={},
+        )
+    ).json().get(&#34;ok&#34;, False)</code></pre>
+</details>
+<div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
+that have not been written to disk.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> on success.</p></div>
 </dd>
 <dt id="couchdb3.aio.AsyncServer.replicate"><code class="name flex">
 <span>async def <span class="ident">replicate</span></span>(<span>self,<br>source: dict | str,<br>target: dict | str,<br>replication_id: str | None = None,<br>cancel: bool | None = None,<br>continuous: bool | None = None,<br>create_target: bool | None = None,<br>create_target_params: dict | None = None,<br>doc_ids: list[str] | None = None,<br>filter_func: str | None = None,<br>selector: dict | None = None,<br>source_proxy: str | None = None,<br>target_proxy: str | None = None) ‑> dict</span>
@@ -4524,6 +5444,184 @@ instance and performing a <code>check</code> request.</p>
 <dd>&nbsp;</dd>
 </dl></div>
 </dd>
+<dt id="couchdb3.aio.AsyncServer.set_node_config"><code class="name flex">
+<span>async def <span class="ident">set_node_config</span></span>(<span>self, section: str, key: str, value: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def set_node_config(
+    self,
+    section: str,
+    key: str,
+    value: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Updates a single configuration value on a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    value : str
+        New value (must be a valid JSON string).
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The previous value of the configuration key.
+    &#34;&#34;&#34;
+    return (
+        await self._put(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+            body=value,
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Updates a single configuration value on a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>str</code></dt>
+<dd>New value (must be a valid JSON string).</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The previous value of the configuration key.</p></div>
+</dd>
+<dt id="couchdb3.aio.AsyncServer.setup_cluster"><code class="name flex">
+<span>async def <span class="ident">setup_cluster</span></span>(<span>self,<br>action: str,<br>*,<br>bind_address: str | None = None,<br>username: str | None = None,<br>password: str | None = None,<br>port: int | None = None,<br>node_count: int | None = None,<br>remote_node: str | None = None,<br>remote_current_user: str | None = None,<br>remote_current_password: str | None = None,<br>host: str | None = None,<br>ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def setup_cluster(
+    self,
+    action: str,
+    *,
+    bind_address: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    port: int | None = None,
+    node_count: int | None = None,
+    remote_node: str | None = None,
+    remote_current_user: str | None = None,
+    remote_current_password: str | None = None,
+    host: str | None = None,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Configure a node as a single (standalone) node, as part of a cluster, or finalise
+    a cluster. This is a **destructive** operation — do not run against a shared or
+    production CouchDB instance during testing.
+
+    Parameters
+    ----------
+    action : str
+        One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+        ``&#39;finish_cluster&#39;``.
+    bind_address : str
+        IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+        (``enable_cluster`` and ``enable_single_node`` only)
+    username : str
+        Server-level administrator username to create, or the remote server&#39;s
+        administrator username (``add_node``).
+    password : str
+        Server-level administrator password to create, or the remote server&#39;s password
+        (``add_node``).
+    port : int
+        TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+        remote node&#39;s port (``add_node``).
+    node_count : int
+        Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+        (``enable_cluster`` only)
+    remote_node : str
+        IP address of the remote node. (``enable_cluster`` only)
+    remote_current_user : str
+        Username of the admin on the remote node. (``enable_cluster`` only)
+    remote_current_password : str
+        Password of the admin on the remote node. (``enable_cluster`` only)
+    host : str
+        Remote node IP to add to the cluster. (``add_node`` only)
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist. Defaults to
+        ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : ``{&#34;ok&#34;: true}`` on success.
+    &#34;&#34;&#34;
+    return (
+        await self._post(
+            resource=&#34;_cluster_setup&#34;,
+            body=rm_nones_from_dict(
+                {
+                    &#34;action&#34;: action,
+                    &#34;bind_address&#34;: bind_address,
+                    &#34;username&#34;: username,
+                    &#34;password&#34;: password,
+                    &#34;port&#34;: port,
+                    &#34;node_count&#34;: node_count,
+                    &#34;remote_node&#34;: remote_node,
+                    &#34;remote_current_user&#34;: remote_current_user,
+                    &#34;remote_current_password&#34;: remote_current_password,
+                    &#34;host&#34;: host,
+                    &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+                }
+            ),
+        )
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Configure a node as a single (standalone) node, as part of a cluster, or finalise
+a cluster. This is a <strong>destructive</strong> operation — do not run against a shared or
+production CouchDB instance during testing.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>action</code></strong> :&ensp;<code>str</code></dt>
+<dd>One of <code>'enable_single_node'</code>, <code>'enable_cluster'</code>, <code>'add_node'</code>, or
+<code>'finish_cluster'</code>.</dd>
+<dt><strong><code>bind_address</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address to bind the current node. Use <code>'0.0.0.0'</code> to bind all interfaces.
+(<code>enable_cluster</code> and <code>enable_single_node</code> only)</dd>
+<dt><strong><code>username</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator username to create, or the remote server's
+administrator username (<code>add_node</code>).</dd>
+<dt><strong><code>password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator password to create, or the remote server's password
+(<code>add_node</code>).</dd>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>TCP port for this node (<code>enable_cluster</code> / <code>enable_single_node</code>) or the
+remote node's port (<code>add_node</code>).</dd>
+<dt><strong><code>node_count</code></strong> :&ensp;<code>int</code></dt>
+<dd>Total number of nodes to join into the cluster. Determines <code>n</code> (max 3).
+(<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_node</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address of the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_user</code></strong> :&ensp;<code>str</code></dt>
+<dd>Username of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Password of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>host</code></strong> :&ensp;<code>str</code></dt>
+<dd>Remote node IP to add to the cluster. (<code>add_node</code> only)</dd>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist. Defaults to
+<code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : <code>{"ok": true}</code> on success.</p></div>
+</dd>
 <dt id="couchdb3.aio.AsyncServer.up"><code class="name flex">
 <span>async def <span class="ident">up</span></span>(<span>self, raise_exception: bool = False) ‑> bool</span>
 </code></dt>
@@ -4604,6 +5702,7 @@ instance and performing a <code>check</code> request.</p>
 <li><code><a title="couchdb3.aio.AsyncDatabase.all_docs" href="#couchdb3.aio.AsyncDatabase.all_docs">all_docs</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.bulk_docs" href="#couchdb3.aio.AsyncDatabase.bulk_docs">bulk_docs</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.bulk_get" href="#couchdb3.aio.AsyncDatabase.bulk_get">bulk_get</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncDatabase.changes" href="#couchdb3.aio.AsyncDatabase.changes">changes</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.compact" href="#couchdb3.aio.AsyncDatabase.compact">compact</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.copy" href="#couchdb3.aio.AsyncDatabase.copy">copy</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.create" href="#couchdb3.aio.AsyncDatabase.create">create</a></code></li>
@@ -4654,12 +5753,21 @@ instance and performing a <code>check</code> request.</p>
 <li><code><a title="couchdb3.aio.AsyncServer.active_tasks" href="#couchdb3.aio.AsyncServer.active_tasks">active_tasks</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.all_dbs" href="#couchdb3.aio.AsyncServer.all_dbs">all_dbs</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.check_user" href="#couchdb3.aio.AsyncServer.check_user">check_user</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.cluster_setup" href="#couchdb3.aio.AsyncServer.cluster_setup">cluster_setup</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.create" href="#couchdb3.aio.AsyncServer.create">create</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.dbs_info" href="#couchdb3.aio.AsyncServer.dbs_info">dbs_info</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.delete" href="#couchdb3.aio.AsyncServer.delete">delete</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.delete_node_config" href="#couchdb3.aio.AsyncServer.delete_node_config">delete_node_config</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.get" href="#couchdb3.aio.AsyncServer.get">get</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.membership" href="#couchdb3.aio.AsyncServer.membership">membership</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.node_config" href="#couchdb3.aio.AsyncServer.node_config">node_config</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.node_stats" href="#couchdb3.aio.AsyncServer.node_stats">node_stats</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.node_system" href="#couchdb3.aio.AsyncServer.node_system">node_system</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.reload_node_config" href="#couchdb3.aio.AsyncServer.reload_node_config">reload_node_config</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.replicate" href="#couchdb3.aio.AsyncServer.replicate">replicate</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.save_user" href="#couchdb3.aio.AsyncServer.save_user">save_user</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.set_node_config" href="#couchdb3.aio.AsyncServer.set_node_config">set_node_config</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.setup_cluster" href="#couchdb3.aio.AsyncServer.setup_cluster">setup_cluster</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.up" href="#couchdb3.aio.AsyncServer.up">up</a></code></li>
 </ul>
 </li>

--- a/docs/sync/database.html
+++ b/docs/sync/database.html
@@ -1262,9 +1262,7 @@ el.replaceWith(d);
                 &#34;in a future release.&#34;
             )
         if doc_ids is not None and selector is not None:
-            raise CouchDBError(
-                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-            )
+            raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
         query_kwargs = {
             &#34;conflicts&#34;: conflicts,
             &#34;descending&#34;: descending,
@@ -1668,9 +1666,7 @@ that lists the parent revisions if <code>revs=true</code>.</li>
             &#34;in a future release.&#34;
         )
     if doc_ids is not None and selector is not None:
-        raise CouchDBError(
-            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-        )
+        raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
     query_kwargs = {
         &#34;conflicts&#34;: conflicts,
         &#34;descending&#34;: descending,

--- a/docs/sync/database.html
+++ b/docs/sync/database.html
@@ -1163,6 +1163,140 @@ el.replaceWith(d);
             ).json()
         )
 
+    def changes(
+        self,
+        *,
+        doc_ids: list[str] | None = None,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        feed: str | None = None,
+        filter: str | None = None,
+        heartbeat: int | None = None,
+        include_docs: bool | None = None,
+        attachments: bool | None = None,
+        att_encoding_info: bool | None = None,
+        limit: int | None = None,
+        since: str | None = None,
+        style: str | None = None,
+        timeout: int | None = None,
+        view: str | None = None,
+        seq_interval: int | None = None,
+        selector: dict | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns a sorted list of changes made to documents in the database. Only the most
+        recent change for a given document is included.
+
+        When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+        ``filter=_doc_ids``. When `selector` is provided it is sent as
+        ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+        ``GET /{db}/_changes``.
+
+        .. note::
+            ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+            method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+            addressed in a future ``changes_stream()`` method.
+
+        Parameters
+        ----------
+        doc_ids : list[str]
+            List of document IDs to filter the changes feed. Triggers a POST request with
+            ``filter=_doc_ids``. Mutually exclusive with `selector`.
+        conflicts : bool
+            Include conflicts information. Only effective when `include_docs` is `True`.
+        descending : bool
+            Return changes in descending sequence order. Default `False`.
+        feed : str
+            Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+            ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+        filter : str
+            Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+            ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+            `doc_ids` / `selector` parameters instead.
+        heartbeat : int
+            Milliseconds between heartbeat newlines for ``longpoll`` feed.
+        include_docs : bool
+            Include the associated document with each result. Default `False`.
+        attachments : bool
+            Include Base64-encoded attachment content when `include_docs` is `True`.
+        att_encoding_info : bool
+            Include encoding info in attachment stubs when `include_docs` is `True`.
+        limit : int
+            Maximum number of rows to return.
+        since : str
+            Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+            future changes.
+        style : str
+            Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+        timeout : int
+            Maximum milliseconds to wait for a change (``longpoll`` only).
+        view : str
+            View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+        seq_interval : int
+            Calculate update sequence every N results (reduces server load on large
+            sharded databases).
+        selector : dict
+            Mango selector to filter documents. Triggers a POST request with
+            ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``last_seq`` (`str`) — last change update sequence
+          - ``pending`` (`int`) — count of remaining items in the feed
+          - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+            ``changes``, and optionally ``deleted`` / ``doc``
+
+        Raises
+        ------
+        ValueError
+            If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+        CouchDBError
+            If both `doc_ids` and `selector` are provided.
+        &#34;&#34;&#34;
+        if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+            raise ValueError(
+                f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+                &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+                &#34;in a future release.&#34;
+            )
+        if doc_ids is not None and selector is not None:
+            raise CouchDBError(
+                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+            )
+        query_kwargs = {
+            &#34;conflicts&#34;: conflicts,
+            &#34;descending&#34;: descending,
+            &#34;feed&#34;: feed,
+            &#34;filter&#34;: filter,
+            &#34;heartbeat&#34;: heartbeat,
+            &#34;include_docs&#34;: include_docs,
+            &#34;attachments&#34;: attachments,
+            &#34;att_encoding_info&#34;: att_encoding_info,
+            &#34;limit&#34;: limit,
+            &#34;since&#34;: since,
+            &#34;style&#34;: style,
+            &#34;timeout&#34;: timeout,
+            &#34;view&#34;: view,
+            &#34;seq_interval&#34;: seq_interval,
+        }
+        if doc_ids is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+            return self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;doc_ids&#34;: doc_ids},
+                query_kwargs=query_kwargs,
+            ).json()
+        if selector is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+            return self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;selector&#34;: selector},
+                query_kwargs=query_kwargs,
+            ).json()
+        return self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs).json()
+
     def get_partition(self, partition_id: str) -&gt; Partition:
         &#34;&#34;&#34;
         Get a given partition.
@@ -1426,6 +1560,218 @@ that lists the parent revisions if <code>revs=true</code>.</li>
 &gt;&gt;&gt; for item in results:
 ...     print(item[&quot;id&quot;], item[&quot;docs&quot;][0][&quot;ok&quot;])
 </code></pre></div>
+</dd>
+<dt id="couchdb3.sync.database.Database.changes"><code class="name flex">
+<span>def <span class="ident">changes</span></span>(<span>self,<br>*,<br>doc_ids: list[str] | None = None,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>feed: str | None = None,<br>filter: str | None = None,<br>heartbeat: int | None = None,<br>include_docs: bool | None = None,<br>attachments: bool | None = None,<br>att_encoding_info: bool | None = None,<br>limit: int | None = None,<br>since: str | None = None,<br>style: str | None = None,<br>timeout: int | None = None,<br>view: str | None = None,<br>seq_interval: int | None = None,<br>selector: dict | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def changes(
+    self,
+    *,
+    doc_ids: list[str] | None = None,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    feed: str | None = None,
+    filter: str | None = None,
+    heartbeat: int | None = None,
+    include_docs: bool | None = None,
+    attachments: bool | None = None,
+    att_encoding_info: bool | None = None,
+    limit: int | None = None,
+    since: str | None = None,
+    style: str | None = None,
+    timeout: int | None = None,
+    view: str | None = None,
+    seq_interval: int | None = None,
+    selector: dict | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns a sorted list of changes made to documents in the database. Only the most
+    recent change for a given document is included.
+
+    When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+    ``filter=_doc_ids``. When `selector` is provided it is sent as
+    ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+    ``GET /{db}/_changes``.
+
+    .. note::
+        ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+        method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+        addressed in a future ``changes_stream()`` method.
+
+    Parameters
+    ----------
+    doc_ids : list[str]
+        List of document IDs to filter the changes feed. Triggers a POST request with
+        ``filter=_doc_ids``. Mutually exclusive with `selector`.
+    conflicts : bool
+        Include conflicts information. Only effective when `include_docs` is `True`.
+    descending : bool
+        Return changes in descending sequence order. Default `False`.
+    feed : str
+        Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+        ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+    filter : str
+        Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+        ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+        `doc_ids` / `selector` parameters instead.
+    heartbeat : int
+        Milliseconds between heartbeat newlines for ``longpoll`` feed.
+    include_docs : bool
+        Include the associated document with each result. Default `False`.
+    attachments : bool
+        Include Base64-encoded attachment content when `include_docs` is `True`.
+    att_encoding_info : bool
+        Include encoding info in attachment stubs when `include_docs` is `True`.
+    limit : int
+        Maximum number of rows to return.
+    since : str
+        Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+        future changes.
+    style : str
+        Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+    timeout : int
+        Maximum milliseconds to wait for a change (``longpoll`` only).
+    view : str
+        View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+    seq_interval : int
+        Calculate update sequence every N results (reduces server load on large
+        sharded databases).
+    selector : dict
+        Mango selector to filter documents. Triggers a POST request with
+        ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``last_seq`` (`str`) — last change update sequence
+      - ``pending`` (`int`) — count of remaining items in the feed
+      - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+        ``changes``, and optionally ``deleted`` / ``doc``
+
+    Raises
+    ------
+    ValueError
+        If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+    CouchDBError
+        If both `doc_ids` and `selector` are provided.
+    &#34;&#34;&#34;
+    if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+        raise ValueError(
+            f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+            &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+            &#34;in a future release.&#34;
+        )
+    if doc_ids is not None and selector is not None:
+        raise CouchDBError(
+            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+        )
+    query_kwargs = {
+        &#34;conflicts&#34;: conflicts,
+        &#34;descending&#34;: descending,
+        &#34;feed&#34;: feed,
+        &#34;filter&#34;: filter,
+        &#34;heartbeat&#34;: heartbeat,
+        &#34;include_docs&#34;: include_docs,
+        &#34;attachments&#34;: attachments,
+        &#34;att_encoding_info&#34;: att_encoding_info,
+        &#34;limit&#34;: limit,
+        &#34;since&#34;: since,
+        &#34;style&#34;: style,
+        &#34;timeout&#34;: timeout,
+        &#34;view&#34;: view,
+        &#34;seq_interval&#34;: seq_interval,
+    }
+    if doc_ids is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+        return self._post(
+            resource=&#34;_changes&#34;,
+            body={&#34;doc_ids&#34;: doc_ids},
+            query_kwargs=query_kwargs,
+        ).json()
+    if selector is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+        return self._post(
+            resource=&#34;_changes&#34;,
+            body={&#34;selector&#34;: selector},
+            query_kwargs=query_kwargs,
+        ).json()
+    return self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs).json()</code></pre>
+</details>
+<div class="desc"><p>Returns a sorted list of changes made to documents in the database. Only the most
+recent change for a given document is included.</p>
+<p>When <code>doc_ids</code> is provided the request is sent as <code>POST /{db}/_changes</code> with
+<code>filter=_doc_ids</code>. When <code>selector</code> is provided it is sent as
+<code>POST /{db}/_changes</code> with <code>filter=_selector</code>. All other cases use
+<code>GET /{db}/_changes</code>.</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p><code>feed='continuous'</code> and <code>feed='eventsource'</code> are <strong>not</strong> supported by this
+method. Passing either value raises :class:<code>ValueError</code>. Streaming feeds will be
+addressed in a future <code>changes_stream()</code> method.</p>
+</div>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>doc_ids</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of document IDs to filter the changes feed. Triggers a POST request with
+<code>filter=_doc_ids</code>. Mutually exclusive with <code>selector</code>.</dd>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Only effective when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return changes in descending sequence order. Default <code>False</code>.</dd>
+<dt><strong><code>feed</code></strong> :&ensp;<code>str</code></dt>
+<dd>Feed type. Supported values: <code>'normal'</code> (default), <code>'longpoll'</code>.
+<code>'continuous'</code> and <code>'eventsource'</code> are not supported.</dd>
+<dt><strong><code>filter</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of a filter function (<code>'design_doc/filter_name'</code>, <code>'_design'</code>, or
+<code>'_view'</code>). Do not pass <code>'_doc_ids'</code> or <code>'_selector'</code> manually — use the
+<code>doc_ids</code> / <code>selector</code> parameters instead.</dd>
+<dt><strong><code>heartbeat</code></strong> :&ensp;<code>int</code></dt>
+<dd>Milliseconds between heartbeat newlines for <code>longpoll</code> feed.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each result. Default <code>False</code>.</dd>
+<dt><strong><code>attachments</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include Base64-encoded attachment content when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>att_encoding_info</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include encoding info in attachment stubs when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum number of rows to return.</dd>
+<dt><strong><code>since</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return only changes after the given update sequence. Use <code>'now'</code> to get only
+future changes.</dd>
+<dt><strong><code>style</code></strong> :&ensp;<code>str</code></dt>
+<dd>Revision style. <code>'main_only'</code> (default) or <code>'all_docs'</code>.</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum milliseconds to wait for a change (<code>longpoll</code> only).</dd>
+<dt><strong><code>view</code></strong> :&ensp;<code>str</code></dt>
+<dd>View function to use as a filter (requires <code>filter='_view'</code>).</dd>
+<dt><strong><code>seq_interval</code></strong> :&ensp;<code>int</code></dt>
+<dd>Calculate update sequence every N results (reduces server load on large
+sharded databases).</dd>
+<dt><strong><code>selector</code></strong> :&ensp;<code>dict</code></dt>
+<dd>Mango selector to filter documents. Triggers a POST request with
+<code>filter=_selector</code>. Mutually exclusive with <code>doc_ids</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>last_seq</code> (<code>str</code>) — last change update sequence</li>
+<li><code>pending</code> (<code>int</code>) — count of remaining items in the feed</li>
+<li><code>results</code> (<code>list</code>) — list of change objects, each with <code>id</code>, <code>seq</code>,
+<code>changes</code>, and optionally <code>deleted</code> / <code>doc</code></li>
+</ul>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>feed</code> is <code>'continuous'</code> or <code>'eventsource'</code>.</dd>
+<dt><code>CouchDBError</code></dt>
+<dd>If both <code>doc_ids</code> and <code>selector</code> are provided.</dd>
+</dl></div>
 </dd>
 <dt id="couchdb3.sync.database.Database.compact"><code class="name flex">
 <span>def <span class="ident">compact</span></span>(<span>self, ddoc: str | None = None) ‑> bool</span>
@@ -4284,6 +4630,7 @@ view reflects. Default is <code>False</code>.</dd>
 <ul class="hlist">
 <li><code><b><a title="couchdb3.sync.database.Database" href="#couchdb3.sync.database.Database">Database</a></b></code>:
 <ul class="hlist">
+<li><code><a title="couchdb3.sync.database.Database.changes" href="#couchdb3.sync.database.Database.changes">changes</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.check" href="base.html#couchdb3.sync.base.Base.check">check</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.compact" href="#couchdb3.sync.database.Database.compact">compact</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.explain" href="#couchdb3.sync.database.Database.explain">explain</a></code></li>
@@ -4321,6 +4668,7 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.all_docs" href="#couchdb3.sync.database.Database.all_docs">all_docs</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.bulk_docs" href="#couchdb3.sync.database.Database.bulk_docs">bulk_docs</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.bulk_get" href="#couchdb3.sync.database.Database.bulk_get">bulk_get</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.changes" href="#couchdb3.sync.database.Database.changes">changes</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.compact" href="#couchdb3.sync.database.Database.compact">compact</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.copy" href="#couchdb3.sync.database.Database.copy">copy</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.create" href="#couchdb3.sync.database.Database.create">create</a></code></li>

--- a/docs/sync/index.html
+++ b/docs/sync/index.html
@@ -1183,6 +1183,140 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             ).json()
         )
 
+    def changes(
+        self,
+        *,
+        doc_ids: list[str] | None = None,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        feed: str | None = None,
+        filter: str | None = None,
+        heartbeat: int | None = None,
+        include_docs: bool | None = None,
+        attachments: bool | None = None,
+        att_encoding_info: bool | None = None,
+        limit: int | None = None,
+        since: str | None = None,
+        style: str | None = None,
+        timeout: int | None = None,
+        view: str | None = None,
+        seq_interval: int | None = None,
+        selector: dict | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns a sorted list of changes made to documents in the database. Only the most
+        recent change for a given document is included.
+
+        When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+        ``filter=_doc_ids``. When `selector` is provided it is sent as
+        ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+        ``GET /{db}/_changes``.
+
+        .. note::
+            ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+            method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+            addressed in a future ``changes_stream()`` method.
+
+        Parameters
+        ----------
+        doc_ids : list[str]
+            List of document IDs to filter the changes feed. Triggers a POST request with
+            ``filter=_doc_ids``. Mutually exclusive with `selector`.
+        conflicts : bool
+            Include conflicts information. Only effective when `include_docs` is `True`.
+        descending : bool
+            Return changes in descending sequence order. Default `False`.
+        feed : str
+            Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+            ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+        filter : str
+            Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+            ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+            `doc_ids` / `selector` parameters instead.
+        heartbeat : int
+            Milliseconds between heartbeat newlines for ``longpoll`` feed.
+        include_docs : bool
+            Include the associated document with each result. Default `False`.
+        attachments : bool
+            Include Base64-encoded attachment content when `include_docs` is `True`.
+        att_encoding_info : bool
+            Include encoding info in attachment stubs when `include_docs` is `True`.
+        limit : int
+            Maximum number of rows to return.
+        since : str
+            Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+            future changes.
+        style : str
+            Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+        timeout : int
+            Maximum milliseconds to wait for a change (``longpoll`` only).
+        view : str
+            View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+        seq_interval : int
+            Calculate update sequence every N results (reduces server load on large
+            sharded databases).
+        selector : dict
+            Mango selector to filter documents. Triggers a POST request with
+            ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``last_seq`` (`str`) — last change update sequence
+          - ``pending`` (`int`) — count of remaining items in the feed
+          - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+            ``changes``, and optionally ``deleted`` / ``doc``
+
+        Raises
+        ------
+        ValueError
+            If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+        CouchDBError
+            If both `doc_ids` and `selector` are provided.
+        &#34;&#34;&#34;
+        if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+            raise ValueError(
+                f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+                &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+                &#34;in a future release.&#34;
+            )
+        if doc_ids is not None and selector is not None:
+            raise CouchDBError(
+                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+            )
+        query_kwargs = {
+            &#34;conflicts&#34;: conflicts,
+            &#34;descending&#34;: descending,
+            &#34;feed&#34;: feed,
+            &#34;filter&#34;: filter,
+            &#34;heartbeat&#34;: heartbeat,
+            &#34;include_docs&#34;: include_docs,
+            &#34;attachments&#34;: attachments,
+            &#34;att_encoding_info&#34;: att_encoding_info,
+            &#34;limit&#34;: limit,
+            &#34;since&#34;: since,
+            &#34;style&#34;: style,
+            &#34;timeout&#34;: timeout,
+            &#34;view&#34;: view,
+            &#34;seq_interval&#34;: seq_interval,
+        }
+        if doc_ids is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+            return self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;doc_ids&#34;: doc_ids},
+                query_kwargs=query_kwargs,
+            ).json()
+        if selector is not None:
+            query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+            return self._post(
+                resource=&#34;_changes&#34;,
+                body={&#34;selector&#34;: selector},
+                query_kwargs=query_kwargs,
+            ).json()
+        return self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs).json()
+
     def get_partition(self, partition_id: str) -&gt; Partition:
         &#34;&#34;&#34;
         Get a given partition.
@@ -1446,6 +1580,218 @@ that lists the parent revisions if <code>revs=true</code>.</li>
 &gt;&gt;&gt; for item in results:
 ...     print(item[&quot;id&quot;], item[&quot;docs&quot;][0][&quot;ok&quot;])
 </code></pre></div>
+</dd>
+<dt id="couchdb3.sync.Database.changes"><code class="name flex">
+<span>def <span class="ident">changes</span></span>(<span>self,<br>*,<br>doc_ids: list[str] | None = None,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>feed: str | None = None,<br>filter: str | None = None,<br>heartbeat: int | None = None,<br>include_docs: bool | None = None,<br>attachments: bool | None = None,<br>att_encoding_info: bool | None = None,<br>limit: int | None = None,<br>since: str | None = None,<br>style: str | None = None,<br>timeout: int | None = None,<br>view: str | None = None,<br>seq_interval: int | None = None,<br>selector: dict | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def changes(
+    self,
+    *,
+    doc_ids: list[str] | None = None,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    feed: str | None = None,
+    filter: str | None = None,
+    heartbeat: int | None = None,
+    include_docs: bool | None = None,
+    attachments: bool | None = None,
+    att_encoding_info: bool | None = None,
+    limit: int | None = None,
+    since: str | None = None,
+    style: str | None = None,
+    timeout: int | None = None,
+    view: str | None = None,
+    seq_interval: int | None = None,
+    selector: dict | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns a sorted list of changes made to documents in the database. Only the most
+    recent change for a given document is included.
+
+    When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+    ``filter=_doc_ids``. When `selector` is provided it is sent as
+    ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+    ``GET /{db}/_changes``.
+
+    .. note::
+        ``feed=&#39;continuous&#39;`` and ``feed=&#39;eventsource&#39;`` are **not** supported by this
+        method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+        addressed in a future ``changes_stream()`` method.
+
+    Parameters
+    ----------
+    doc_ids : list[str]
+        List of document IDs to filter the changes feed. Triggers a POST request with
+        ``filter=_doc_ids``. Mutually exclusive with `selector`.
+    conflicts : bool
+        Include conflicts information. Only effective when `include_docs` is `True`.
+    descending : bool
+        Return changes in descending sequence order. Default `False`.
+    feed : str
+        Feed type. Supported values: ``&#39;normal&#39;`` (default), ``&#39;longpoll&#39;``.
+        ``&#39;continuous&#39;`` and ``&#39;eventsource&#39;`` are not supported.
+    filter : str
+        Name of a filter function (``&#39;design_doc/filter_name&#39;``, ``&#39;_design&#39;``, or
+        ``&#39;_view&#39;``). Do not pass ``&#39;_doc_ids&#39;`` or ``&#39;_selector&#39;`` manually — use the
+        `doc_ids` / `selector` parameters instead.
+    heartbeat : int
+        Milliseconds between heartbeat newlines for ``longpoll`` feed.
+    include_docs : bool
+        Include the associated document with each result. Default `False`.
+    attachments : bool
+        Include Base64-encoded attachment content when `include_docs` is `True`.
+    att_encoding_info : bool
+        Include encoding info in attachment stubs when `include_docs` is `True`.
+    limit : int
+        Maximum number of rows to return.
+    since : str
+        Return only changes after the given update sequence. Use ``&#39;now&#39;`` to get only
+        future changes.
+    style : str
+        Revision style. ``&#39;main_only&#39;`` (default) or ``&#39;all_docs&#39;``.
+    timeout : int
+        Maximum milliseconds to wait for a change (``longpoll`` only).
+    view : str
+        View function to use as a filter (requires ``filter=&#39;_view&#39;``).
+    seq_interval : int
+        Calculate update sequence every N results (reduces server load on large
+        sharded databases).
+    selector : dict
+        Mango selector to filter documents. Triggers a POST request with
+        ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``last_seq`` (`str`) — last change update sequence
+      - ``pending`` (`int`) — count of remaining items in the feed
+      - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+        ``changes``, and optionally ``deleted`` / ``doc``
+
+    Raises
+    ------
+    ValueError
+        If ``feed`` is ``&#39;continuous&#39;`` or ``&#39;eventsource&#39;``.
+    CouchDBError
+        If both `doc_ids` and `selector` are provided.
+    &#34;&#34;&#34;
+    if feed in (&#34;continuous&#34;, &#34;eventsource&#34;):
+        raise ValueError(
+            f&#34;feed={feed!r} is not supported by changes(). Use feed=&#39;normal&#39; or &#34;
+            &#34;&#39;longpoll&#39;. Streaming feeds will be available via changes_stream() &#34;
+            &#34;in a future release.&#34;
+        )
+    if doc_ids is not None and selector is not None:
+        raise CouchDBError(
+            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
+        )
+    query_kwargs = {
+        &#34;conflicts&#34;: conflicts,
+        &#34;descending&#34;: descending,
+        &#34;feed&#34;: feed,
+        &#34;filter&#34;: filter,
+        &#34;heartbeat&#34;: heartbeat,
+        &#34;include_docs&#34;: include_docs,
+        &#34;attachments&#34;: attachments,
+        &#34;att_encoding_info&#34;: att_encoding_info,
+        &#34;limit&#34;: limit,
+        &#34;since&#34;: since,
+        &#34;style&#34;: style,
+        &#34;timeout&#34;: timeout,
+        &#34;view&#34;: view,
+        &#34;seq_interval&#34;: seq_interval,
+    }
+    if doc_ids is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_doc_ids&#34;
+        return self._post(
+            resource=&#34;_changes&#34;,
+            body={&#34;doc_ids&#34;: doc_ids},
+            query_kwargs=query_kwargs,
+        ).json()
+    if selector is not None:
+        query_kwargs[&#34;filter&#34;] = &#34;_selector&#34;
+        return self._post(
+            resource=&#34;_changes&#34;,
+            body={&#34;selector&#34;: selector},
+            query_kwargs=query_kwargs,
+        ).json()
+    return self._get(resource=&#34;_changes&#34;, query_kwargs=query_kwargs).json()</code></pre>
+</details>
+<div class="desc"><p>Returns a sorted list of changes made to documents in the database. Only the most
+recent change for a given document is included.</p>
+<p>When <code>doc_ids</code> is provided the request is sent as <code>POST /{db}/_changes</code> with
+<code>filter=_doc_ids</code>. When <code>selector</code> is provided it is sent as
+<code>POST /{db}/_changes</code> with <code>filter=_selector</code>. All other cases use
+<code>GET /{db}/_changes</code>.</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p><code>feed='continuous'</code> and <code>feed='eventsource'</code> are <strong>not</strong> supported by this
+method. Passing either value raises :class:<code>ValueError</code>. Streaming feeds will be
+addressed in a future <code>changes_stream()</code> method.</p>
+</div>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>doc_ids</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of document IDs to filter the changes feed. Triggers a POST request with
+<code>filter=_doc_ids</code>. Mutually exclusive with <code>selector</code>.</dd>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Only effective when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return changes in descending sequence order. Default <code>False</code>.</dd>
+<dt><strong><code>feed</code></strong> :&ensp;<code>str</code></dt>
+<dd>Feed type. Supported values: <code>'normal'</code> (default), <code>'longpoll'</code>.
+<code>'continuous'</code> and <code>'eventsource'</code> are not supported.</dd>
+<dt><strong><code>filter</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of a filter function (<code>'design_doc/filter_name'</code>, <code>'_design'</code>, or
+<code>'_view'</code>). Do not pass <code>'_doc_ids'</code> or <code>'_selector'</code> manually — use the
+<code>doc_ids</code> / <code>selector</code> parameters instead.</dd>
+<dt><strong><code>heartbeat</code></strong> :&ensp;<code>int</code></dt>
+<dd>Milliseconds between heartbeat newlines for <code>longpoll</code> feed.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each result. Default <code>False</code>.</dd>
+<dt><strong><code>attachments</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include Base64-encoded attachment content when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>att_encoding_info</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include encoding info in attachment stubs when <code>include_docs</code> is <code>True</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum number of rows to return.</dd>
+<dt><strong><code>since</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return only changes after the given update sequence. Use <code>'now'</code> to get only
+future changes.</dd>
+<dt><strong><code>style</code></strong> :&ensp;<code>str</code></dt>
+<dd>Revision style. <code>'main_only'</code> (default) or <code>'all_docs'</code>.</dd>
+<dt><strong><code>timeout</code></strong> :&ensp;<code>int</code></dt>
+<dd>Maximum milliseconds to wait for a change (<code>longpoll</code> only).</dd>
+<dt><strong><code>view</code></strong> :&ensp;<code>str</code></dt>
+<dd>View function to use as a filter (requires <code>filter='_view'</code>).</dd>
+<dt><strong><code>seq_interval</code></strong> :&ensp;<code>int</code></dt>
+<dd>Calculate update sequence every N results (reduces server load on large
+sharded databases).</dd>
+<dt><strong><code>selector</code></strong> :&ensp;<code>dict</code></dt>
+<dd>Mango selector to filter documents. Triggers a POST request with
+<code>filter=_selector</code>. Mutually exclusive with <code>doc_ids</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>last_seq</code> (<code>str</code>) — last change update sequence</li>
+<li><code>pending</code> (<code>int</code>) — count of remaining items in the feed</li>
+<li><code>results</code> (<code>list</code>) — list of change objects, each with <code>id</code>, <code>seq</code>,
+<code>changes</code>, and optionally <code>deleted</code> / <code>doc</code></li>
+</ul>
+<h2 id="raises">Raises</h2>
+<dl>
+<dt><code>ValueError</code></dt>
+<dd>If <code>feed</code> is <code>'continuous'</code> or <code>'eventsource'</code>.</dd>
+<dt><code>CouchDBError</code></dt>
+<dd>If both <code>doc_ids</code> and <code>selector</code> are provided.</dd>
+</dl></div>
 </dd>
 <dt id="couchdb3.sync.Database.compact"><code class="name flex">
 <span>def <span class="ident">compact</span></span>(<span>self, ddoc: str | None = None) ‑> bool</span>
@@ -4304,6 +4650,7 @@ view reflects. Default is <code>False</code>.</dd>
 <ul class="hlist">
 <li><code><b><a title="couchdb3.sync.database.Database" href="database.html#couchdb3.sync.database.Database">Database</a></b></code>:
 <ul class="hlist">
+<li><code><a title="couchdb3.sync.database.Database.changes" href="database.html#couchdb3.sync.database.Database.changes">changes</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.check" href="base.html#couchdb3.sync.base.Base.check">check</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.compact" href="database.html#couchdb3.sync.database.Database.compact">compact</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.explain" href="database.html#couchdb3.sync.database.Database.explain">explain</a></code></li>
@@ -4748,6 +5095,259 @@ view reflects. Default is <code>False</code>.</dd>
             ),
         ).json()
 
+    def membership(self) -&gt; dict:
+        &#34;&#34;&#34;
+        Displays the nodes that are part of the cluster.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+          - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+        &#34;&#34;&#34;
+        return self._get(resource=&#34;_membership&#34;).json()
+
+    def cluster_setup(
+        self,
+        *,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns the status of the node or cluster, per the cluster setup wizard.
+
+        Parameters
+        ----------
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist on the node/cluster.
+            Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : A dictionary with a single key ``state`` whose value is one of
+        ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+        ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+        &#34;&#34;&#34;
+        return self._get(
+            resource=&#34;_cluster_setup&#34;,
+            query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+        ).json()
+
+    def setup_cluster(
+        self,
+        action: str,
+        *,
+        bind_address: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        port: int | None = None,
+        node_count: int | None = None,
+        remote_node: str | None = None,
+        remote_current_user: str | None = None,
+        remote_current_password: str | None = None,
+        host: str | None = None,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Configure a node as a single (standalone) node, as part of a cluster, or finalise
+        a cluster. This is a **destructive** operation — do not run against a shared or
+        production CouchDB instance during testing.
+
+        Parameters
+        ----------
+        action : str
+            One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+            ``&#39;finish_cluster&#39;``.
+        bind_address : str
+            IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+            (``enable_cluster`` and ``enable_single_node`` only)
+        username : str
+            Server-level administrator username to create, or the remote server&#39;s
+            administrator username (``add_node``).
+        password : str
+            Server-level administrator password to create, or the remote server&#39;s password
+            (``add_node``).
+        port : int
+            TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+            remote node&#39;s port (``add_node``).
+        node_count : int
+            Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+            (``enable_cluster`` only)
+        remote_node : str
+            IP address of the remote node. (``enable_cluster`` only)
+        remote_current_user : str
+            Username of the admin on the remote node. (``enable_cluster`` only)
+        remote_current_password : str
+            Password of the admin on the remote node. (``enable_cluster`` only)
+        host : str
+            Remote node IP to add to the cluster. (``add_node`` only)
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist. Defaults to
+            ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : ``{&#34;ok&#34;: true}`` on success.
+        &#34;&#34;&#34;
+        return self._post(
+            resource=&#34;_cluster_setup&#34;,
+            body=rm_nones_from_dict(
+                {
+                    &#34;action&#34;: action,
+                    &#34;bind_address&#34;: bind_address,
+                    &#34;username&#34;: username,
+                    &#34;password&#34;: password,
+                    &#34;port&#34;: port,
+                    &#34;node_count&#34;: node_count,
+                    &#34;remote_node&#34;: remote_node,
+                    &#34;remote_current_user&#34;: remote_current_user,
+                    &#34;remote_current_password&#34;: remote_current_password,
+                    &#34;host&#34;: host,
+                    &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+                }
+            ),
+        ).json()
+
+    def node_config(
+        self,
+        node: str = &#34;_local&#34;,
+        section: str | None = None,
+        key: str | None = None,
+    ) -&gt; dict | str:
+        &#34;&#34;&#34;
+        Returns CouchDB node configuration.
+
+        - No `section` / `key` → full configuration tree (`dict`)
+        - `section` only → configuration section (`dict`)
+        - `section` + `key` → single configuration value (`str` or primitive)
+
+        The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+        section : str
+            Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+        key : str
+            Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+        Returns
+        -------
+        dict | str
+        &#34;&#34;&#34;
+        resource = f&#34;_node/{node}/_config&#34;
+        if section:
+            resource = f&#34;{resource}/{section}&#34;
+            if key:
+                resource = f&#34;{resource}/{key}&#34;
+        return self._get(resource=resource).json()
+
+    def set_node_config(
+        self,
+        section: str,
+        key: str,
+        value: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Updates a single configuration value on a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        value : str
+            New value (must be a valid JSON string).
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The previous value of the configuration key.
+        &#34;&#34;&#34;
+        return self._put(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+            body=value,
+        ).json()
+
+    def delete_node_config(
+        self,
+        section: str,
+        key: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Deletes a single configuration value from a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The deleted value.
+        &#34;&#34;&#34;
+        return self._delete(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+        ).json()
+
+    def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Reloads the configuration from disk. Flushes any in-memory configuration changes
+        that have not been written to disk.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        bool : ``True`` on success.
+        &#34;&#34;&#34;
+        return self._post(
+            resource=f&#34;_node/{node}/_config/_reload&#34;,
+            body={},
+        ).json().get(&#34;ok&#34;, False)
+
+    def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return self._get(resource=f&#34;_node/{node}/_stats&#34;).json()
+
+    def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns system-level statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return self._get(resource=f&#34;_node/{node}/_system&#34;).json()
+
     def up(
         self,
         raise_exception: bool = False,
@@ -4936,6 +5536,54 @@ request.</p>
 <h2 id="returns">Returns</h2>
 <p>bool : A boolean indicating if the username/password combination is valid.</p></div>
 </dd>
+<dt id="couchdb3.sync.Server.cluster_setup"><code class="name flex">
+<span>def <span class="ident">cluster_setup</span></span>(<span>self, *, ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def cluster_setup(
+    self,
+    *,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns the status of the node or cluster, per the cluster setup wizard.
+
+    Parameters
+    ----------
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist on the node/cluster.
+        Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : A dictionary with a single key ``state`` whose value is one of
+    ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+    ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+    &#34;&#34;&#34;
+    return self._get(
+        resource=&#34;_cluster_setup&#34;,
+        query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Returns the status of the node or cluster, per the cluster setup wizard.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist on the node/cluster.
+Defaults to <code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>dict</code></strong> :&ensp;<code>A dictionary with a single key <code>state</code> whose value is one of</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p><code>'cluster_disabled'</code>, <code>'single_node_disabled'</code>, <code>'single_node_enabled'</code>,
+<code>'cluster_enabled'</code>, or <code>'cluster_finished'</code>.</p></div>
+</dd>
 <dt id="couchdb3.sync.Server.create"><code class="name flex">
 <span>def <span class="ident">create</span></span>(<span>self,<br>name: str,<br>q: int | None = None,<br>n: int | None = None,<br>partitioned: bool = False) ‑> <a title="couchdb3.sync.database.Database" href="database.html#couchdb3.sync.database.Database">Database</a></span>
 </code></dt>
@@ -5059,6 +5707,53 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
 <h2 id="returns">Returns</h2>
 <p>bool: <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.sync.Server.delete_node_config"><code class="name flex">
+<span>def <span class="ident">delete_node_config</span></span>(<span>self, section: str, key: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def delete_node_config(
+    self,
+    section: str,
+    key: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Deletes a single configuration value from a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The deleted value.
+    &#34;&#34;&#34;
+    return self._delete(
+        resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Deletes a single configuration value from a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The deleted value.</p></div>
+</dd>
 <dt id="couchdb3.sync.Server.get"><code class="name flex">
 <span>def <span class="ident">get</span></span>(<span>self, name: str, check: bool = False) ‑> <a title="couchdb3.sync.database.Database" href="database.html#couchdb3.sync.database.Database">Database</a></span>
 </code></dt>
@@ -5114,6 +5809,207 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
 <dt><code><a title="couchdb3.sync.Database" href="#couchdb3.sync.Database">Database</a></code></dt>
 <dd>&nbsp;</dd>
 </dl></div>
+</dd>
+<dt id="couchdb3.sync.Server.membership"><code class="name flex">
+<span>def <span class="ident">membership</span></span>(<span>self) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def membership(self) -&gt; dict:
+    &#34;&#34;&#34;
+    Displays the nodes that are part of the cluster.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+      - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+    &#34;&#34;&#34;
+    return self._get(resource=&#34;_membership&#34;).json()</code></pre>
+</details>
+<div class="desc"><p>Displays the nodes that are part of the cluster.</p>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>all_nodes</code> (<code>list[str]</code>) — all nodes this node knows about</li>
+<li><code>cluster_nodes</code> (<code>list[str]</code>) — nodes that are part of the cluster</li>
+</ul></div>
+</dd>
+<dt id="couchdb3.sync.Server.node_config"><code class="name flex">
+<span>def <span class="ident">node_config</span></span>(<span>self, node: str = '_local', section: str | None = None, key: str | None = None) ‑> dict | str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def node_config(
+    self,
+    node: str = &#34;_local&#34;,
+    section: str | None = None,
+    key: str | None = None,
+) -&gt; dict | str:
+    &#34;&#34;&#34;
+    Returns CouchDB node configuration.
+
+    - No `section` / `key` → full configuration tree (`dict`)
+    - `section` only → configuration section (`dict`)
+    - `section` + `key` → single configuration value (`str` or primitive)
+
+    The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+    section : str
+        Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+    key : str
+        Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+    Returns
+    -------
+    dict | str
+    &#34;&#34;&#34;
+    resource = f&#34;_node/{node}/_config&#34;
+    if section:
+        resource = f&#34;{resource}/{section}&#34;
+        if key:
+            resource = f&#34;{resource}/{key}&#34;
+    return self._get(resource=resource).json()</code></pre>
+</details>
+<div class="desc"><p>Returns CouchDB node configuration.</p>
+<ul>
+<li>No <code>section</code> / <code>key</code> → full configuration tree (<code>dict</code>)</li>
+<li><code>section</code> only → configuration section (<code>dict</code>)</li>
+<li><code>section</code> + <code>key</code> → single configuration value (<code>str</code> or primitive)</li>
+</ul>
+<p>The literal string <code>'_local'</code> (default) is an alias for the local node name.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name (e.g. <code>'log'</code>, <code>'couchdb'</code>).</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key within the section (e.g. <code>'level'</code>).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict | str</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.sync.Server.node_stats"><code class="name flex">
+<span>def <span class="ident">node_stats</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return self._get(resource=f&#34;_node/{node}/_stats&#34;).json()</code></pre>
+</details>
+<div class="desc"><p>Returns statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.sync.Server.node_system"><code class="name flex">
+<span>def <span class="ident">node_system</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns system-level statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return self._get(resource=f&#34;_node/{node}/_system&#34;).json()</code></pre>
+</details>
+<div class="desc"><p>Returns system-level statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.sync.Server.reload_node_config"><code class="name flex">
+<span>def <span class="ident">reload_node_config</span></span>(<span>self, node: str = '_local') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Reloads the configuration from disk. Flushes any in-memory configuration changes
+    that have not been written to disk.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    bool : ``True`` on success.
+    &#34;&#34;&#34;
+    return self._post(
+        resource=f&#34;_node/{node}/_config/_reload&#34;,
+        body={},
+    ).json().get(&#34;ok&#34;, False)</code></pre>
+</details>
+<div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
+that have not been written to disk.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> on success.</p></div>
 </dd>
 <dt id="couchdb3.sync.Server.replicate"><code class="name flex">
 <span>def <span class="ident">replicate</span></span>(<span>self,<br>source: dict | str,<br>target: dict | str,<br>replication_id: str | None = None,<br>cancel: bool | None = None,<br>continuous: bool | None = None,<br>create_target: bool | None = None,<br>create_target_params: dict | None = None,<br>doc_ids: list[str] | None = None,<br>filter_func: str | None = None,<br>selector: dict | None = None,<br>source_proxy: str | None = None,<br>target_proxy: str | None = None) ‑> dict</span>
@@ -5415,6 +6311,180 @@ stored.</dd>
 <li>the current revision ( <code>str</code>)</li>
 </ul></div>
 </dd>
+<dt id="couchdb3.sync.Server.set_node_config"><code class="name flex">
+<span>def <span class="ident">set_node_config</span></span>(<span>self, section: str, key: str, value: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_node_config(
+    self,
+    section: str,
+    key: str,
+    value: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Updates a single configuration value on a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    value : str
+        New value (must be a valid JSON string).
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The previous value of the configuration key.
+    &#34;&#34;&#34;
+    return self._put(
+        resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+        body=value,
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Updates a single configuration value on a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>str</code></dt>
+<dd>New value (must be a valid JSON string).</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The previous value of the configuration key.</p></div>
+</dd>
+<dt id="couchdb3.sync.Server.setup_cluster"><code class="name flex">
+<span>def <span class="ident">setup_cluster</span></span>(<span>self,<br>action: str,<br>*,<br>bind_address: str | None = None,<br>username: str | None = None,<br>password: str | None = None,<br>port: int | None = None,<br>node_count: int | None = None,<br>remote_node: str | None = None,<br>remote_current_user: str | None = None,<br>remote_current_password: str | None = None,<br>host: str | None = None,<br>ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setup_cluster(
+    self,
+    action: str,
+    *,
+    bind_address: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    port: int | None = None,
+    node_count: int | None = None,
+    remote_node: str | None = None,
+    remote_current_user: str | None = None,
+    remote_current_password: str | None = None,
+    host: str | None = None,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Configure a node as a single (standalone) node, as part of a cluster, or finalise
+    a cluster. This is a **destructive** operation — do not run against a shared or
+    production CouchDB instance during testing.
+
+    Parameters
+    ----------
+    action : str
+        One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+        ``&#39;finish_cluster&#39;``.
+    bind_address : str
+        IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+        (``enable_cluster`` and ``enable_single_node`` only)
+    username : str
+        Server-level administrator username to create, or the remote server&#39;s
+        administrator username (``add_node``).
+    password : str
+        Server-level administrator password to create, or the remote server&#39;s password
+        (``add_node``).
+    port : int
+        TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+        remote node&#39;s port (``add_node``).
+    node_count : int
+        Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+        (``enable_cluster`` only)
+    remote_node : str
+        IP address of the remote node. (``enable_cluster`` only)
+    remote_current_user : str
+        Username of the admin on the remote node. (``enable_cluster`` only)
+    remote_current_password : str
+        Password of the admin on the remote node. (``enable_cluster`` only)
+    host : str
+        Remote node IP to add to the cluster. (``add_node`` only)
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist. Defaults to
+        ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : ``{&#34;ok&#34;: true}`` on success.
+    &#34;&#34;&#34;
+    return self._post(
+        resource=&#34;_cluster_setup&#34;,
+        body=rm_nones_from_dict(
+            {
+                &#34;action&#34;: action,
+                &#34;bind_address&#34;: bind_address,
+                &#34;username&#34;: username,
+                &#34;password&#34;: password,
+                &#34;port&#34;: port,
+                &#34;node_count&#34;: node_count,
+                &#34;remote_node&#34;: remote_node,
+                &#34;remote_current_user&#34;: remote_current_user,
+                &#34;remote_current_password&#34;: remote_current_password,
+                &#34;host&#34;: host,
+                &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+            }
+        ),
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Configure a node as a single (standalone) node, as part of a cluster, or finalise
+a cluster. This is a <strong>destructive</strong> operation — do not run against a shared or
+production CouchDB instance during testing.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>action</code></strong> :&ensp;<code>str</code></dt>
+<dd>One of <code>'enable_single_node'</code>, <code>'enable_cluster'</code>, <code>'add_node'</code>, or
+<code>'finish_cluster'</code>.</dd>
+<dt><strong><code>bind_address</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address to bind the current node. Use <code>'0.0.0.0'</code> to bind all interfaces.
+(<code>enable_cluster</code> and <code>enable_single_node</code> only)</dd>
+<dt><strong><code>username</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator username to create, or the remote server's
+administrator username (<code>add_node</code>).</dd>
+<dt><strong><code>password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator password to create, or the remote server's password
+(<code>add_node</code>).</dd>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>TCP port for this node (<code>enable_cluster</code> / <code>enable_single_node</code>) or the
+remote node's port (<code>add_node</code>).</dd>
+<dt><strong><code>node_count</code></strong> :&ensp;<code>int</code></dt>
+<dd>Total number of nodes to join into the cluster. Determines <code>n</code> (max 3).
+(<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_node</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address of the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_user</code></strong> :&ensp;<code>str</code></dt>
+<dd>Username of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Password of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>host</code></strong> :&ensp;<code>str</code></dt>
+<dd>Remote node IP to add to the cluster. (<code>add_node</code> only)</dd>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist. Defaults to
+<code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : <code>{"ok": true}</code> on success.</p></div>
+</dd>
 <dt id="couchdb3.sync.Server.up"><code class="name flex">
 <span>def <span class="ident">up</span></span>(<span>self, raise_exception: bool = False) ‑> bool</span>
 </code></dt>
@@ -5497,6 +6567,7 @@ stored.</dd>
 <li><code><a title="couchdb3.sync.Database.all_docs" href="#couchdb3.sync.Database.all_docs">all_docs</a></code></li>
 <li><code><a title="couchdb3.sync.Database.bulk_docs" href="#couchdb3.sync.Database.bulk_docs">bulk_docs</a></code></li>
 <li><code><a title="couchdb3.sync.Database.bulk_get" href="#couchdb3.sync.Database.bulk_get">bulk_get</a></code></li>
+<li><code><a title="couchdb3.sync.Database.changes" href="#couchdb3.sync.Database.changes">changes</a></code></li>
 <li><code><a title="couchdb3.sync.Database.compact" href="#couchdb3.sync.Database.compact">compact</a></code></li>
 <li><code><a title="couchdb3.sync.Database.copy" href="#couchdb3.sync.Database.copy">copy</a></code></li>
 <li><code><a title="couchdb3.sync.Database.create" href="#couchdb3.sync.Database.create">create</a></code></li>
@@ -5547,12 +6618,21 @@ stored.</dd>
 <li><code><a title="couchdb3.sync.Server.active_tasks" href="#couchdb3.sync.Server.active_tasks">active_tasks</a></code></li>
 <li><code><a title="couchdb3.sync.Server.all_dbs" href="#couchdb3.sync.Server.all_dbs">all_dbs</a></code></li>
 <li><code><a title="couchdb3.sync.Server.check_user" href="#couchdb3.sync.Server.check_user">check_user</a></code></li>
+<li><code><a title="couchdb3.sync.Server.cluster_setup" href="#couchdb3.sync.Server.cluster_setup">cluster_setup</a></code></li>
 <li><code><a title="couchdb3.sync.Server.create" href="#couchdb3.sync.Server.create">create</a></code></li>
 <li><code><a title="couchdb3.sync.Server.dbs_info" href="#couchdb3.sync.Server.dbs_info">dbs_info</a></code></li>
 <li><code><a title="couchdb3.sync.Server.delete" href="#couchdb3.sync.Server.delete">delete</a></code></li>
+<li><code><a title="couchdb3.sync.Server.delete_node_config" href="#couchdb3.sync.Server.delete_node_config">delete_node_config</a></code></li>
 <li><code><a title="couchdb3.sync.Server.get" href="#couchdb3.sync.Server.get">get</a></code></li>
+<li><code><a title="couchdb3.sync.Server.membership" href="#couchdb3.sync.Server.membership">membership</a></code></li>
+<li><code><a title="couchdb3.sync.Server.node_config" href="#couchdb3.sync.Server.node_config">node_config</a></code></li>
+<li><code><a title="couchdb3.sync.Server.node_stats" href="#couchdb3.sync.Server.node_stats">node_stats</a></code></li>
+<li><code><a title="couchdb3.sync.Server.node_system" href="#couchdb3.sync.Server.node_system">node_system</a></code></li>
+<li><code><a title="couchdb3.sync.Server.reload_node_config" href="#couchdb3.sync.Server.reload_node_config">reload_node_config</a></code></li>
 <li><code><a title="couchdb3.sync.Server.replicate" href="#couchdb3.sync.Server.replicate">replicate</a></code></li>
 <li><code><a title="couchdb3.sync.Server.save_user" href="#couchdb3.sync.Server.save_user">save_user</a></code></li>
+<li><code><a title="couchdb3.sync.Server.set_node_config" href="#couchdb3.sync.Server.set_node_config">set_node_config</a></code></li>
+<li><code><a title="couchdb3.sync.Server.setup_cluster" href="#couchdb3.sync.Server.setup_cluster">setup_cluster</a></code></li>
 <li><code><a title="couchdb3.sync.Server.up" href="#couchdb3.sync.Server.up">up</a></code></li>
 </ul>
 </li>

--- a/docs/sync/index.html
+++ b/docs/sync/index.html
@@ -1282,9 +1282,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
                 &#34;in a future release.&#34;
             )
         if doc_ids is not None and selector is not None:
-            raise CouchDBError(
-                &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-            )
+            raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
         query_kwargs = {
             &#34;conflicts&#34;: conflicts,
             &#34;descending&#34;: descending,
@@ -1688,9 +1686,7 @@ that lists the parent revisions if <code>revs=true</code>.</li>
             &#34;in a future release.&#34;
         )
     if doc_ids is not None and selector is not None:
-        raise CouchDBError(
-            &#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;
-        )
+        raise CouchDBError(&#34;Arguments &#39;doc_ids&#39; and &#39;selector&#39; are mutually exclusive.&#34;)
     query_kwargs = {
         &#34;conflicts&#34;: conflicts,
         &#34;descending&#34;: descending,
@@ -5313,10 +5309,14 @@ view reflects. Default is <code>False</code>.</dd>
         -------
         bool : ``True`` on success.
         &#34;&#34;&#34;
-        return self._post(
-            resource=f&#34;_node/{node}/_config/_reload&#34;,
-            body={},
-        ).json().get(&#34;ok&#34;, False)
+        return (
+            self._post(
+                resource=f&#34;_node/{node}/_config/_reload&#34;,
+                body={},
+            )
+            .json()
+            .get(&#34;ok&#34;, False)
+        )
 
     def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
         &#34;&#34;&#34;
@@ -5996,10 +5996,14 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
     -------
     bool : ``True`` on success.
     &#34;&#34;&#34;
-    return self._post(
-        resource=f&#34;_node/{node}/_config/_reload&#34;,
-        body={},
-    ).json().get(&#34;ok&#34;, False)</code></pre>
+    return (
+        self._post(
+            resource=f&#34;_node/{node}/_config/_reload&#34;,
+            body={},
+        )
+        .json()
+        .get(&#34;ok&#34;, False)
+    )</code></pre>
 </details>
 <div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
 that have not been written to disk.</p>

--- a/docs/sync/server.html
+++ b/docs/sync/server.html
@@ -474,6 +474,259 @@ el.replaceWith(d);
             ),
         ).json()
 
+    def membership(self) -&gt; dict:
+        &#34;&#34;&#34;
+        Displays the nodes that are part of the cluster.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+          - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+        &#34;&#34;&#34;
+        return self._get(resource=&#34;_membership&#34;).json()
+
+    def cluster_setup(
+        self,
+        *,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns the status of the node or cluster, per the cluster setup wizard.
+
+        Parameters
+        ----------
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist on the node/cluster.
+            Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : A dictionary with a single key ``state`` whose value is one of
+        ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+        ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+        &#34;&#34;&#34;
+        return self._get(
+            resource=&#34;_cluster_setup&#34;,
+            query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+        ).json()
+
+    def setup_cluster(
+        self,
+        action: str,
+        *,
+        bind_address: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        port: int | None = None,
+        node_count: int | None = None,
+        remote_node: str | None = None,
+        remote_current_user: str | None = None,
+        remote_current_password: str | None = None,
+        host: str | None = None,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -&gt; dict:
+        &#34;&#34;&#34;
+        Configure a node as a single (standalone) node, as part of a cluster, or finalise
+        a cluster. This is a **destructive** operation — do not run against a shared or
+        production CouchDB instance during testing.
+
+        Parameters
+        ----------
+        action : str
+            One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+            ``&#39;finish_cluster&#39;``.
+        bind_address : str
+            IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+            (``enable_cluster`` and ``enable_single_node`` only)
+        username : str
+            Server-level administrator username to create, or the remote server&#39;s
+            administrator username (``add_node``).
+        password : str
+            Server-level administrator password to create, or the remote server&#39;s password
+            (``add_node``).
+        port : int
+            TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+            remote node&#39;s port (``add_node``).
+        node_count : int
+            Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+            (``enable_cluster`` only)
+        remote_node : str
+            IP address of the remote node. (``enable_cluster`` only)
+        remote_current_user : str
+            Username of the admin on the remote node. (``enable_cluster`` only)
+        remote_current_password : str
+            Password of the admin on the remote node. (``enable_cluster`` only)
+        host : str
+            Remote node IP to add to the cluster. (``add_node`` only)
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist. Defaults to
+            ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+        Returns
+        -------
+        dict : ``{&#34;ok&#34;: true}`` on success.
+        &#34;&#34;&#34;
+        return self._post(
+            resource=&#34;_cluster_setup&#34;,
+            body=rm_nones_from_dict(
+                {
+                    &#34;action&#34;: action,
+                    &#34;bind_address&#34;: bind_address,
+                    &#34;username&#34;: username,
+                    &#34;password&#34;: password,
+                    &#34;port&#34;: port,
+                    &#34;node_count&#34;: node_count,
+                    &#34;remote_node&#34;: remote_node,
+                    &#34;remote_current_user&#34;: remote_current_user,
+                    &#34;remote_current_password&#34;: remote_current_password,
+                    &#34;host&#34;: host,
+                    &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+                }
+            ),
+        ).json()
+
+    def node_config(
+        self,
+        node: str = &#34;_local&#34;,
+        section: str | None = None,
+        key: str | None = None,
+    ) -&gt; dict | str:
+        &#34;&#34;&#34;
+        Returns CouchDB node configuration.
+
+        - No `section` / `key` → full configuration tree (`dict`)
+        - `section` only → configuration section (`dict`)
+        - `section` + `key` → single configuration value (`str` or primitive)
+
+        The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+        section : str
+            Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+        key : str
+            Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+        Returns
+        -------
+        dict | str
+        &#34;&#34;&#34;
+        resource = f&#34;_node/{node}/_config&#34;
+        if section:
+            resource = f&#34;{resource}/{section}&#34;
+            if key:
+                resource = f&#34;{resource}/{key}&#34;
+        return self._get(resource=resource).json()
+
+    def set_node_config(
+        self,
+        section: str,
+        key: str,
+        value: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Updates a single configuration value on a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        value : str
+            New value (must be a valid JSON string).
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The previous value of the configuration key.
+        &#34;&#34;&#34;
+        return self._put(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+            body=value,
+        ).json()
+
+    def delete_node_config(
+        self,
+        section: str,
+        key: str,
+        node: str = &#34;_local&#34;,
+    ) -&gt; str:
+        &#34;&#34;&#34;
+        Deletes a single configuration value from a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        str : The deleted value.
+        &#34;&#34;&#34;
+        return self._delete(
+            resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+        ).json()
+
+    def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Reloads the configuration from disk. Flushes any in-memory configuration changes
+        that have not been written to disk.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        bool : ``True`` on success.
+        &#34;&#34;&#34;
+        return self._post(
+            resource=f&#34;_node/{node}/_config/_reload&#34;,
+            body={},
+        ).json().get(&#34;ok&#34;, False)
+
+    def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return self._get(resource=f&#34;_node/{node}/_stats&#34;).json()
+
+    def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+        &#34;&#34;&#34;
+        Returns system-level statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``&#39;_local&#39;``.
+
+        Returns
+        -------
+        dict
+        &#34;&#34;&#34;
+        return self._get(resource=f&#34;_node/{node}/_system&#34;).json()
+
     def up(
         self,
         raise_exception: bool = False,
@@ -662,6 +915,54 @@ request.</p>
 <h2 id="returns">Returns</h2>
 <p>bool : A boolean indicating if the username/password combination is valid.</p></div>
 </dd>
+<dt id="couchdb3.sync.server.Server.cluster_setup"><code class="name flex">
+<span>def <span class="ident">cluster_setup</span></span>(<span>self, *, ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def cluster_setup(
+    self,
+    *,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns the status of the node or cluster, per the cluster setup wizard.
+
+    Parameters
+    ----------
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist on the node/cluster.
+        Defaults to ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : A dictionary with a single key ``state`` whose value is one of
+    ``&#39;cluster_disabled&#39;``, ``&#39;single_node_disabled&#39;``, ``&#39;single_node_enabled&#39;``,
+    ``&#39;cluster_enabled&#39;``, or ``&#39;cluster_finished&#39;``.
+    &#34;&#34;&#34;
+    return self._get(
+        resource=&#34;_cluster_setup&#34;,
+        query_kwargs={&#34;ensure_dbs_exist&#34;: ensure_dbs_exist},
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Returns the status of the node or cluster, per the cluster setup wizard.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist on the node/cluster.
+Defaults to <code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><strong><code>dict</code></strong> :&ensp;<code>A dictionary with a single key <code>state</code> whose value is one of</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p><code>'cluster_disabled'</code>, <code>'single_node_disabled'</code>, <code>'single_node_enabled'</code>,
+<code>'cluster_enabled'</code>, or <code>'cluster_finished'</code>.</p></div>
+</dd>
 <dt id="couchdb3.sync.server.Server.create"><code class="name flex">
 <span>def <span class="ident">create</span></span>(<span>self,<br>name: str,<br>q: int | None = None,<br>n: int | None = None,<br>partitioned: bool = False) ‑> <a title="couchdb3.sync.database.Database" href="database.html#couchdb3.sync.database.Database">Database</a></span>
 </code></dt>
@@ -785,6 +1086,53 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
 <h2 id="returns">Returns</h2>
 <p>bool: <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.sync.server.Server.delete_node_config"><code class="name flex">
+<span>def <span class="ident">delete_node_config</span></span>(<span>self, section: str, key: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def delete_node_config(
+    self,
+    section: str,
+    key: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Deletes a single configuration value from a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The deleted value.
+    &#34;&#34;&#34;
+    return self._delete(
+        resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Deletes a single configuration value from a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The deleted value.</p></div>
+</dd>
 <dt id="couchdb3.sync.server.Server.get"><code class="name flex">
 <span>def <span class="ident">get</span></span>(<span>self, name: str, check: bool = False) ‑> <a title="couchdb3.sync.database.Database" href="database.html#couchdb3.sync.database.Database">Database</a></span>
 </code></dt>
@@ -840,6 +1188,207 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
 <dt><code><a title="couchdb3.sync.Database" href="index.html#couchdb3.sync.Database">Database</a></code></dt>
 <dd>&nbsp;</dd>
 </dl></div>
+</dd>
+<dt id="couchdb3.sync.server.Server.membership"><code class="name flex">
+<span>def <span class="ident">membership</span></span>(<span>self) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def membership(self) -&gt; dict:
+    &#34;&#34;&#34;
+    Displays the nodes that are part of the cluster.
+
+    Returns
+    -------
+    dict : A dictionary with the following keys.
+
+      - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+      - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+    &#34;&#34;&#34;
+    return self._get(resource=&#34;_membership&#34;).json()</code></pre>
+</details>
+<div class="desc"><p>Displays the nodes that are part of the cluster.</p>
+<h2 id="returns">Returns</h2>
+<p>dict : A dictionary with the following keys.</p>
+<ul>
+<li><code>all_nodes</code> (<code>list[str]</code>) — all nodes this node knows about</li>
+<li><code>cluster_nodes</code> (<code>list[str]</code>) — nodes that are part of the cluster</li>
+</ul></div>
+</dd>
+<dt id="couchdb3.sync.server.Server.node_config"><code class="name flex">
+<span>def <span class="ident">node_config</span></span>(<span>self, node: str = '_local', section: str | None = None, key: str | None = None) ‑> dict | str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def node_config(
+    self,
+    node: str = &#34;_local&#34;,
+    section: str | None = None,
+    key: str | None = None,
+) -&gt; dict | str:
+    &#34;&#34;&#34;
+    Returns CouchDB node configuration.
+
+    - No `section` / `key` → full configuration tree (`dict`)
+    - `section` only → configuration section (`dict`)
+    - `section` + `key` → single configuration value (`str` or primitive)
+
+    The literal string ``&#39;_local&#39;`` (default) is an alias for the local node name.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+    section : str
+        Configuration section name (e.g. ``&#39;log&#39;``, ``&#39;couchdb&#39;``).
+    key : str
+        Configuration key within the section (e.g. ``&#39;level&#39;``).
+
+    Returns
+    -------
+    dict | str
+    &#34;&#34;&#34;
+    resource = f&#34;_node/{node}/_config&#34;
+    if section:
+        resource = f&#34;{resource}/{section}&#34;
+        if key:
+            resource = f&#34;{resource}/{key}&#34;
+    return self._get(resource=resource).json()</code></pre>
+</details>
+<div class="desc"><p>Returns CouchDB node configuration.</p>
+<ul>
+<li>No <code>section</code> / <code>key</code> → full configuration tree (<code>dict</code>)</li>
+<li><code>section</code> only → configuration section (<code>dict</code>)</li>
+<li><code>section</code> + <code>key</code> → single configuration value (<code>str</code> or primitive)</li>
+</ul>
+<p>The literal string <code>'_local'</code> (default) is an alias for the local node name.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name (e.g. <code>'log'</code>, <code>'couchdb'</code>).</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key within the section (e.g. <code>'level'</code>).</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict | str</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.sync.server.Server.node_stats"><code class="name flex">
+<span>def <span class="ident">node_stats</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return self._get(resource=f&#34;_node/{node}/_stats&#34;).json()</code></pre>
+</details>
+<div class="desc"><p>Returns statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.sync.server.Server.node_system"><code class="name flex">
+<span>def <span class="ident">node_system</span></span>(<span>self, node: str = '_local') ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def node_system(self, node: str = &#34;_local&#34;) -&gt; dict:
+    &#34;&#34;&#34;
+    Returns system-level statistics for the specified node.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    dict
+    &#34;&#34;&#34;
+    return self._get(resource=f&#34;_node/{node}/_system&#34;).json()</code></pre>
+</details>
+<div class="desc"><p>Returns system-level statistics for the specified node.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>dict</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+<dt id="couchdb3.sync.server.Server.reload_node_config"><code class="name flex">
+<span>def <span class="ident">reload_node_config</span></span>(<span>self, node: str = '_local') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def reload_node_config(self, node: str = &#34;_local&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Reloads the configuration from disk. Flushes any in-memory configuration changes
+    that have not been written to disk.
+
+    Parameters
+    ----------
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    bool : ``True`` on success.
+    &#34;&#34;&#34;
+    return self._post(
+        resource=f&#34;_node/{node}/_config/_reload&#34;,
+        body={},
+    ).json().get(&#34;ok&#34;, False)</code></pre>
+</details>
+<div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
+that have not been written to disk.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> on success.</p></div>
 </dd>
 <dt id="couchdb3.sync.server.Server.replicate"><code class="name flex">
 <span>def <span class="ident">replicate</span></span>(<span>self,<br>source: dict | str,<br>target: dict | str,<br>replication_id: str | None = None,<br>cancel: bool | None = None,<br>continuous: bool | None = None,<br>create_target: bool | None = None,<br>create_target_params: dict | None = None,<br>doc_ids: list[str] | None = None,<br>filter_func: str | None = None,<br>selector: dict | None = None,<br>source_proxy: str | None = None,<br>target_proxy: str | None = None) ‑> dict</span>
@@ -1141,6 +1690,180 @@ stored.</dd>
 <li>the current revision ( <code>str</code>)</li>
 </ul></div>
 </dd>
+<dt id="couchdb3.sync.server.Server.set_node_config"><code class="name flex">
+<span>def <span class="ident">set_node_config</span></span>(<span>self, section: str, key: str, value: str, node: str = '_local') ‑> str</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_node_config(
+    self,
+    section: str,
+    key: str,
+    value: str,
+    node: str = &#34;_local&#34;,
+) -&gt; str:
+    &#34;&#34;&#34;
+    Updates a single configuration value on a node. Returns the **old** value.
+
+    Parameters
+    ----------
+    section : str
+        Configuration section name.
+    key : str
+        Configuration key name.
+    value : str
+        New value (must be a valid JSON string).
+    node : str
+        Node name. Default ``&#39;_local&#39;``.
+
+    Returns
+    -------
+    str : The previous value of the configuration key.
+    &#34;&#34;&#34;
+    return self._put(
+        resource=f&#34;_node/{node}/_config/{section}/{key}&#34;,
+        body=value,
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Updates a single configuration value on a node. Returns the <strong>old</strong> value.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>section</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration section name.</dd>
+<dt><strong><code>key</code></strong> :&ensp;<code>str</code></dt>
+<dd>Configuration key name.</dd>
+<dt><strong><code>value</code></strong> :&ensp;<code>str</code></dt>
+<dd>New value (must be a valid JSON string).</dd>
+<dt><strong><code>node</code></strong> :&ensp;<code>str</code></dt>
+<dd>Node name. Default <code>'_local'</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>str : The previous value of the configuration key.</p></div>
+</dd>
+<dt id="couchdb3.sync.server.Server.setup_cluster"><code class="name flex">
+<span>def <span class="ident">setup_cluster</span></span>(<span>self,<br>action: str,<br>*,<br>bind_address: str | None = None,<br>username: str | None = None,<br>password: str | None = None,<br>port: int | None = None,<br>node_count: int | None = None,<br>remote_node: str | None = None,<br>remote_current_user: str | None = None,<br>remote_current_password: str | None = None,<br>host: str | None = None,<br>ensure_dbs_exist: list[str] | None = None) ‑> dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def setup_cluster(
+    self,
+    action: str,
+    *,
+    bind_address: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    port: int | None = None,
+    node_count: int | None = None,
+    remote_node: str | None = None,
+    remote_current_user: str | None = None,
+    remote_current_password: str | None = None,
+    host: str | None = None,
+    ensure_dbs_exist: list[str] | None = None,
+) -&gt; dict:
+    &#34;&#34;&#34;
+    Configure a node as a single (standalone) node, as part of a cluster, or finalise
+    a cluster. This is a **destructive** operation — do not run against a shared or
+    production CouchDB instance during testing.
+
+    Parameters
+    ----------
+    action : str
+        One of ``&#39;enable_single_node&#39;``, ``&#39;enable_cluster&#39;``, ``&#39;add_node&#39;``, or
+        ``&#39;finish_cluster&#39;``.
+    bind_address : str
+        IP address to bind the current node. Use ``&#39;0.0.0.0&#39;`` to bind all interfaces.
+        (``enable_cluster`` and ``enable_single_node`` only)
+    username : str
+        Server-level administrator username to create, or the remote server&#39;s
+        administrator username (``add_node``).
+    password : str
+        Server-level administrator password to create, or the remote server&#39;s password
+        (``add_node``).
+    port : int
+        TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+        remote node&#39;s port (``add_node``).
+    node_count : int
+        Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+        (``enable_cluster`` only)
+    remote_node : str
+        IP address of the remote node. (``enable_cluster`` only)
+    remote_current_user : str
+        Username of the admin on the remote node. (``enable_cluster`` only)
+    remote_current_password : str
+        Password of the admin on the remote node. (``enable_cluster`` only)
+    host : str
+        Remote node IP to add to the cluster. (``add_node`` only)
+    ensure_dbs_exist : list[str]
+        List of system databases to ensure exist. Defaults to
+        ``[&#34;_users&#34;, &#34;_replicator&#34;]``.
+
+    Returns
+    -------
+    dict : ``{&#34;ok&#34;: true}`` on success.
+    &#34;&#34;&#34;
+    return self._post(
+        resource=&#34;_cluster_setup&#34;,
+        body=rm_nones_from_dict(
+            {
+                &#34;action&#34;: action,
+                &#34;bind_address&#34;: bind_address,
+                &#34;username&#34;: username,
+                &#34;password&#34;: password,
+                &#34;port&#34;: port,
+                &#34;node_count&#34;: node_count,
+                &#34;remote_node&#34;: remote_node,
+                &#34;remote_current_user&#34;: remote_current_user,
+                &#34;remote_current_password&#34;: remote_current_password,
+                &#34;host&#34;: host,
+                &#34;ensure_dbs_exist&#34;: ensure_dbs_exist,
+            }
+        ),
+    ).json()</code></pre>
+</details>
+<div class="desc"><p>Configure a node as a single (standalone) node, as part of a cluster, or finalise
+a cluster. This is a <strong>destructive</strong> operation — do not run against a shared or
+production CouchDB instance during testing.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>action</code></strong> :&ensp;<code>str</code></dt>
+<dd>One of <code>'enable_single_node'</code>, <code>'enable_cluster'</code>, <code>'add_node'</code>, or
+<code>'finish_cluster'</code>.</dd>
+<dt><strong><code>bind_address</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address to bind the current node. Use <code>'0.0.0.0'</code> to bind all interfaces.
+(<code>enable_cluster</code> and <code>enable_single_node</code> only)</dd>
+<dt><strong><code>username</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator username to create, or the remote server's
+administrator username (<code>add_node</code>).</dd>
+<dt><strong><code>password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Server-level administrator password to create, or the remote server's password
+(<code>add_node</code>).</dd>
+<dt><strong><code>port</code></strong> :&ensp;<code>int</code></dt>
+<dd>TCP port for this node (<code>enable_cluster</code> / <code>enable_single_node</code>) or the
+remote node's port (<code>add_node</code>).</dd>
+<dt><strong><code>node_count</code></strong> :&ensp;<code>int</code></dt>
+<dd>Total number of nodes to join into the cluster. Determines <code>n</code> (max 3).
+(<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_node</code></strong> :&ensp;<code>str</code></dt>
+<dd>IP address of the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_user</code></strong> :&ensp;<code>str</code></dt>
+<dd>Username of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>remote_current_password</code></strong> :&ensp;<code>str</code></dt>
+<dd>Password of the admin on the remote node. (<code>enable_cluster</code> only)</dd>
+<dt><strong><code>host</code></strong> :&ensp;<code>str</code></dt>
+<dd>Remote node IP to add to the cluster. (<code>add_node</code> only)</dd>
+<dt><strong><code>ensure_dbs_exist</code></strong> :&ensp;<code>list[str]</code></dt>
+<dd>List of system databases to ensure exist. Defaults to
+<code>["_users", "_replicator"]</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>dict : <code>{"ok": true}</code> on success.</p></div>
+</dd>
 <dt id="couchdb3.sync.server.Server.up"><code class="name flex">
 <span>def <span class="ident">up</span></span>(<span>self, raise_exception: bool = False) ‑> bool</span>
 </code></dt>
@@ -1216,12 +1939,21 @@ stored.</dd>
 <li><code><a title="couchdb3.sync.server.Server.active_tasks" href="#couchdb3.sync.server.Server.active_tasks">active_tasks</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.all_dbs" href="#couchdb3.sync.server.Server.all_dbs">all_dbs</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.check_user" href="#couchdb3.sync.server.Server.check_user">check_user</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.cluster_setup" href="#couchdb3.sync.server.Server.cluster_setup">cluster_setup</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.create" href="#couchdb3.sync.server.Server.create">create</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.dbs_info" href="#couchdb3.sync.server.Server.dbs_info">dbs_info</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.delete" href="#couchdb3.sync.server.Server.delete">delete</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.delete_node_config" href="#couchdb3.sync.server.Server.delete_node_config">delete_node_config</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.get" href="#couchdb3.sync.server.Server.get">get</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.membership" href="#couchdb3.sync.server.Server.membership">membership</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.node_config" href="#couchdb3.sync.server.Server.node_config">node_config</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.node_stats" href="#couchdb3.sync.server.Server.node_stats">node_stats</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.node_system" href="#couchdb3.sync.server.Server.node_system">node_system</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.reload_node_config" href="#couchdb3.sync.server.Server.reload_node_config">reload_node_config</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.replicate" href="#couchdb3.sync.server.Server.replicate">replicate</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.save_user" href="#couchdb3.sync.server.Server.save_user">save_user</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.set_node_config" href="#couchdb3.sync.server.Server.set_node_config">set_node_config</a></code></li>
+<li><code><a title="couchdb3.sync.server.Server.setup_cluster" href="#couchdb3.sync.server.Server.setup_cluster">setup_cluster</a></code></li>
 <li><code><a title="couchdb3.sync.server.Server.up" href="#couchdb3.sync.server.Server.up">up</a></code></li>
 </ul>
 </li>

--- a/docs/sync/server.html
+++ b/docs/sync/server.html
@@ -692,10 +692,14 @@ el.replaceWith(d);
         -------
         bool : ``True`` on success.
         &#34;&#34;&#34;
-        return self._post(
-            resource=f&#34;_node/{node}/_config/_reload&#34;,
-            body={},
-        ).json().get(&#34;ok&#34;, False)
+        return (
+            self._post(
+                resource=f&#34;_node/{node}/_config/_reload&#34;,
+                body={},
+            )
+            .json()
+            .get(&#34;ok&#34;, False)
+        )
 
     def node_stats(self, node: str = &#34;_local&#34;) -&gt; dict:
         &#34;&#34;&#34;
@@ -1375,10 +1379,14 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
     -------
     bool : ``True`` on success.
     &#34;&#34;&#34;
-    return self._post(
-        resource=f&#34;_node/{node}/_config/_reload&#34;,
-        body={},
-    ).json().get(&#34;ok&#34;, False)</code></pre>
+    return (
+        self._post(
+            resource=f&#34;_node/{node}/_config/_reload&#34;,
+            body={},
+        )
+        .json()
+        .get(&#34;ok&#34;, False)
+    )</code></pre>
 </details>
 <div class="desc"><p>Reloads the configuration from disk. Flushes any in-memory configuration changes
 that have not been written to disk.</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "couchdb3"
-version = "3.2.1"
+version = "3.3.0"
 description = "A wrapper around the CouchDB API."
 authors = [{ name = "Nikolai Vlahovic", email = "vlahovic.REDACTED_USERlai@gmail.com" }]
 requires-python = ">= 3.11"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="CouchDB3",
-    version="3.2.1",
+    version="3.3.0",
     author="Nikolai Vlahovic",
     author_email="REDACTED_USERlai@nexup.com",
     description="A wrapper around the CouchDB API.",

--- a/src/couchdb3/aio/async_database.py
+++ b/src/couchdb3/aio/async_database.py
@@ -993,6 +993,144 @@ class AsyncDatabase(AsyncBase):
             ).json()
         )
 
+    async def changes(
+        self,
+        *,
+        doc_ids: list[str] | None = None,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        feed: str | None = None,
+        filter: str | None = None,
+        heartbeat: int | None = None,
+        include_docs: bool | None = None,
+        attachments: bool | None = None,
+        att_encoding_info: bool | None = None,
+        limit: int | None = None,
+        since: str | None = None,
+        style: str | None = None,
+        timeout: int | None = None,
+        view: str | None = None,
+        seq_interval: int | None = None,
+        selector: dict | None = None,
+    ) -> dict:
+        """
+        Returns a sorted list of changes made to documents in the database. Only the most
+        recent change for a given document is included.
+
+        When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+        ``filter=_doc_ids``. When `selector` is provided it is sent as
+        ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+        ``GET /{db}/_changes``.
+
+        .. note::
+            ``feed='continuous'`` and ``feed='eventsource'`` are **not** supported by this
+            method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+            addressed in a future ``changes_stream()`` method.
+
+        Parameters
+        ----------
+        doc_ids : list[str]
+            List of document IDs to filter the changes feed. Triggers a POST request with
+            ``filter=_doc_ids``. Mutually exclusive with `selector`.
+        conflicts : bool
+            Include conflicts information. Only effective when `include_docs` is `True`.
+        descending : bool
+            Return changes in descending sequence order. Default `False`.
+        feed : str
+            Feed type. Supported values: ``'normal'`` (default), ``'longpoll'``.
+            ``'continuous'`` and ``'eventsource'`` are not supported.
+        filter : str
+            Name of a filter function (``'design_doc/filter_name'``, ``'_design'``, or
+            ``'_view'``). Do not pass ``'_doc_ids'`` or ``'_selector'`` manually — use the
+            `doc_ids` / `selector` parameters instead.
+        heartbeat : int
+            Milliseconds between heartbeat newlines for ``longpoll`` feed.
+        include_docs : bool
+            Include the associated document with each result. Default `False`.
+        attachments : bool
+            Include Base64-encoded attachment content when `include_docs` is `True`.
+        att_encoding_info : bool
+            Include encoding info in attachment stubs when `include_docs` is `True`.
+        limit : int
+            Maximum number of rows to return.
+        since : str
+            Return only changes after the given update sequence. Use ``'now'`` to get only
+            future changes.
+        style : str
+            Revision style. ``'main_only'`` (default) or ``'all_docs'``.
+        timeout : int
+            Maximum milliseconds to wait for a change (``longpoll`` only).
+        view : str
+            View function to use as a filter (requires ``filter='_view'``).
+        seq_interval : int
+            Calculate update sequence every N results (reduces server load on large
+            sharded databases).
+        selector : dict
+            Mango selector to filter documents. Triggers a POST request with
+            ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``last_seq`` (`str`) — last change update sequence
+          - ``pending`` (`int`) — count of remaining items in the feed
+          - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+            ``changes``, and optionally ``deleted`` / ``doc``
+
+        Raises
+        ------
+        ValueError
+            If ``feed`` is ``'continuous'`` or ``'eventsource'``.
+        CouchDBError
+            If both `doc_ids` and `selector` are provided.
+        """
+        if feed in ("continuous", "eventsource"):
+            raise ValueError(
+                f"feed={feed!r} is not supported by changes(). Use feed='normal' or "
+                "'longpoll'. Streaming feeds will be available via changes_stream() "
+                "in a future release."
+            )
+        if doc_ids is not None and selector is not None:
+            raise CouchDBError(
+                "Arguments 'doc_ids' and 'selector' are mutually exclusive."
+            )
+        query_kwargs = {
+            "conflicts": conflicts,
+            "descending": descending,
+            "feed": feed,
+            "filter": filter,
+            "heartbeat": heartbeat,
+            "include_docs": include_docs,
+            "attachments": attachments,
+            "att_encoding_info": att_encoding_info,
+            "limit": limit,
+            "since": since,
+            "style": style,
+            "timeout": timeout,
+            "view": view,
+            "seq_interval": seq_interval,
+        }
+        if doc_ids is not None:
+            query_kwargs["filter"] = "_doc_ids"
+            return (
+                await self._post(
+                    resource="_changes",
+                    body={"doc_ids": doc_ids},
+                    query_kwargs=query_kwargs,
+                )
+            ).json()
+        if selector is not None:
+            query_kwargs["filter"] = "_selector"
+            return (
+                await self._post(
+                    resource="_changes",
+                    body={"selector": selector},
+                    query_kwargs=query_kwargs,
+                )
+            ).json()
+        return (await self._get(resource="_changes", query_kwargs=query_kwargs)).json()
+
     async def get_partition(self, partition_id: str) -> AsyncPartition:
         """
         Get a given partition.

--- a/src/couchdb3/aio/async_database.py
+++ b/src/couchdb3/aio/async_database.py
@@ -1092,9 +1092,7 @@ class AsyncDatabase(AsyncBase):
                 "in a future release."
             )
         if doc_ids is not None and selector is not None:
-            raise CouchDBError(
-                "Arguments 'doc_ids' and 'selector' are mutually exclusive."
-            )
+            raise CouchDBError("Arguments 'doc_ids' and 'selector' are mutually exclusive.")
         query_kwargs = {
             "conflicts": conflicts,
             "descending": descending,

--- a/src/couchdb3/aio/async_server.py
+++ b/src/couchdb3/aio/async_server.py
@@ -412,6 +412,269 @@ class AsyncServer(AsyncBase):
             )
         ).json()
 
+    async def membership(self) -> dict:
+        """
+        Displays the nodes that are part of the cluster.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+          - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+        """
+        return (await self._get(resource="_membership")).json()
+
+    async def cluster_setup(
+        self,
+        *,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -> dict:
+        """
+        Returns the status of the node or cluster, per the cluster setup wizard.
+
+        Parameters
+        ----------
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist on the node/cluster.
+            Defaults to ``["_users", "_replicator"]``.
+
+        Returns
+        -------
+        dict : A dictionary with a single key ``state`` whose value is one of
+        ``'cluster_disabled'``, ``'single_node_disabled'``, ``'single_node_enabled'``,
+        ``'cluster_enabled'``, or ``'cluster_finished'``.
+        """
+        return (
+            await self._get(
+                resource="_cluster_setup",
+                query_kwargs={"ensure_dbs_exist": ensure_dbs_exist},
+            )
+        ).json()
+
+    async def setup_cluster(
+        self,
+        action: str,
+        *,
+        bind_address: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        port: int | None = None,
+        node_count: int | None = None,
+        remote_node: str | None = None,
+        remote_current_user: str | None = None,
+        remote_current_password: str | None = None,
+        host: str | None = None,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -> dict:
+        """
+        Configure a node as a single (standalone) node, as part of a cluster, or finalise
+        a cluster. This is a **destructive** operation — do not run against a shared or
+        production CouchDB instance during testing.
+
+        Parameters
+        ----------
+        action : str
+            One of ``'enable_single_node'``, ``'enable_cluster'``, ``'add_node'``, or
+            ``'finish_cluster'``.
+        bind_address : str
+            IP address to bind the current node. Use ``'0.0.0.0'`` to bind all interfaces.
+            (``enable_cluster`` and ``enable_single_node`` only)
+        username : str
+            Server-level administrator username to create, or the remote server's
+            administrator username (``add_node``).
+        password : str
+            Server-level administrator password to create, or the remote server's password
+            (``add_node``).
+        port : int
+            TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+            remote node's port (``add_node``).
+        node_count : int
+            Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+            (``enable_cluster`` only)
+        remote_node : str
+            IP address of the remote node. (``enable_cluster`` only)
+        remote_current_user : str
+            Username of the admin on the remote node. (``enable_cluster`` only)
+        remote_current_password : str
+            Password of the admin on the remote node. (``enable_cluster`` only)
+        host : str
+            Remote node IP to add to the cluster. (``add_node`` only)
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist. Defaults to
+            ``["_users", "_replicator"]``.
+
+        Returns
+        -------
+        dict : ``{"ok": true}`` on success.
+        """
+        return (
+            await self._post(
+                resource="_cluster_setup",
+                body=rm_nones_from_dict(
+                    {
+                        "action": action,
+                        "bind_address": bind_address,
+                        "username": username,
+                        "password": password,
+                        "port": port,
+                        "node_count": node_count,
+                        "remote_node": remote_node,
+                        "remote_current_user": remote_current_user,
+                        "remote_current_password": remote_current_password,
+                        "host": host,
+                        "ensure_dbs_exist": ensure_dbs_exist,
+                    }
+                ),
+            )
+        ).json()
+
+    async def node_config(
+        self,
+        node: str = "_local",
+        section: str | None = None,
+        key: str | None = None,
+    ) -> dict | str:
+        """
+        Returns CouchDB node configuration.
+
+        - No `section` / `key` → full configuration tree (`dict`)
+        - `section` only → configuration section (`dict`)
+        - `section` + `key` → single configuration value (`str` or primitive)
+
+        The literal string ``'_local'`` (default) is an alias for the local node name.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+        section : str
+            Configuration section name (e.g. ``'log'``, ``'couchdb'``).
+        key : str
+            Configuration key within the section (e.g. ``'level'``).
+
+        Returns
+        -------
+        dict | str
+        """
+        resource = f"_node/{node}/_config"
+        if section:
+            resource = f"{resource}/{section}"
+            if key:
+                resource = f"{resource}/{key}"
+        return (await self._get(resource=resource)).json()
+
+    async def set_node_config(
+        self,
+        section: str,
+        key: str,
+        value: str,
+        node: str = "_local",
+    ) -> str:
+        """
+        Updates a single configuration value on a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        value : str
+            New value (must be a valid JSON string).
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        str : The previous value of the configuration key.
+        """
+        return (
+            await self._put(
+                resource=f"_node/{node}/_config/{section}/{key}",
+                body=value,
+            )
+        ).json()
+
+    async def delete_node_config(
+        self,
+        section: str,
+        key: str,
+        node: str = "_local",
+    ) -> str:
+        """
+        Deletes a single configuration value from a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        str : The deleted value.
+        """
+        return (
+            await self._delete(
+                resource=f"_node/{node}/_config/{section}/{key}",
+            )
+        ).json()
+
+    async def reload_node_config(self, node: str = "_local") -> bool:
+        """
+        Reloads the configuration from disk. Flushes any in-memory configuration changes
+        that have not been written to disk.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        bool : ``True`` on success.
+        """
+        return (
+            await self._post(
+                resource=f"_node/{node}/_config/_reload",
+                body={},
+            )
+        ).json().get("ok", False)
+
+    async def node_stats(self, node: str = "_local") -> dict:
+        """
+        Returns statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        dict
+        """
+        return (await self._get(resource=f"_node/{node}/_stats")).json()
+
+    async def node_system(self, node: str = "_local") -> dict:
+        """
+        Returns system-level statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        dict
+        """
+        return (await self._get(resource=f"_node/{node}/_system")).json()
+
     async def up(self, raise_exception: bool = False) -> bool:
         """
         Check if the server is up.

--- a/src/couchdb3/aio/async_server.py
+++ b/src/couchdb3/aio/async_server.py
@@ -639,11 +639,15 @@ class AsyncServer(AsyncBase):
         bool : ``True`` on success.
         """
         return (
-            await self._post(
-                resource=f"_node/{node}/_config/_reload",
-                body={},
+            (
+                await self._post(
+                    resource=f"_node/{node}/_config/_reload",
+                    body={},
+                )
             )
-        ).json().get("ok", False)
+            .json()
+            .get("ok", False)
+        )
 
     async def node_stats(self, node: str = "_local") -> dict:
         """

--- a/src/couchdb3/sync/database.py
+++ b/src/couchdb3/sync/database.py
@@ -1138,6 +1138,140 @@ class Database(Base):
             ).json()
         )
 
+    def changes(
+        self,
+        *,
+        doc_ids: list[str] | None = None,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        feed: str | None = None,
+        filter: str | None = None,
+        heartbeat: int | None = None,
+        include_docs: bool | None = None,
+        attachments: bool | None = None,
+        att_encoding_info: bool | None = None,
+        limit: int | None = None,
+        since: str | None = None,
+        style: str | None = None,
+        timeout: int | None = None,
+        view: str | None = None,
+        seq_interval: int | None = None,
+        selector: dict | None = None,
+    ) -> dict:
+        """
+        Returns a sorted list of changes made to documents in the database. Only the most
+        recent change for a given document is included.
+
+        When `doc_ids` is provided the request is sent as ``POST /{db}/_changes`` with
+        ``filter=_doc_ids``. When `selector` is provided it is sent as
+        ``POST /{db}/_changes`` with ``filter=_selector``. All other cases use
+        ``GET /{db}/_changes``.
+
+        .. note::
+            ``feed='continuous'`` and ``feed='eventsource'`` are **not** supported by this
+            method. Passing either value raises :class:`ValueError`. Streaming feeds will be
+            addressed in a future ``changes_stream()`` method.
+
+        Parameters
+        ----------
+        doc_ids : list[str]
+            List of document IDs to filter the changes feed. Triggers a POST request with
+            ``filter=_doc_ids``. Mutually exclusive with `selector`.
+        conflicts : bool
+            Include conflicts information. Only effective when `include_docs` is `True`.
+        descending : bool
+            Return changes in descending sequence order. Default `False`.
+        feed : str
+            Feed type. Supported values: ``'normal'`` (default), ``'longpoll'``.
+            ``'continuous'`` and ``'eventsource'`` are not supported.
+        filter : str
+            Name of a filter function (``'design_doc/filter_name'``, ``'_design'``, or
+            ``'_view'``). Do not pass ``'_doc_ids'`` or ``'_selector'`` manually — use the
+            `doc_ids` / `selector` parameters instead.
+        heartbeat : int
+            Milliseconds between heartbeat newlines for ``longpoll`` feed.
+        include_docs : bool
+            Include the associated document with each result. Default `False`.
+        attachments : bool
+            Include Base64-encoded attachment content when `include_docs` is `True`.
+        att_encoding_info : bool
+            Include encoding info in attachment stubs when `include_docs` is `True`.
+        limit : int
+            Maximum number of rows to return.
+        since : str
+            Return only changes after the given update sequence. Use ``'now'`` to get only
+            future changes.
+        style : str
+            Revision style. ``'main_only'`` (default) or ``'all_docs'``.
+        timeout : int
+            Maximum milliseconds to wait for a change (``longpoll`` only).
+        view : str
+            View function to use as a filter (requires ``filter='_view'``).
+        seq_interval : int
+            Calculate update sequence every N results (reduces server load on large
+            sharded databases).
+        selector : dict
+            Mango selector to filter documents. Triggers a POST request with
+            ``filter=_selector``. Mutually exclusive with `doc_ids`.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``last_seq`` (`str`) — last change update sequence
+          - ``pending`` (`int`) — count of remaining items in the feed
+          - ``results`` (`list`) — list of change objects, each with ``id``, ``seq``,
+            ``changes``, and optionally ``deleted`` / ``doc``
+
+        Raises
+        ------
+        ValueError
+            If ``feed`` is ``'continuous'`` or ``'eventsource'``.
+        CouchDBError
+            If both `doc_ids` and `selector` are provided.
+        """
+        if feed in ("continuous", "eventsource"):
+            raise ValueError(
+                f"feed={feed!r} is not supported by changes(). Use feed='normal' or "
+                "'longpoll'. Streaming feeds will be available via changes_stream() "
+                "in a future release."
+            )
+        if doc_ids is not None and selector is not None:
+            raise CouchDBError(
+                "Arguments 'doc_ids' and 'selector' are mutually exclusive."
+            )
+        query_kwargs = {
+            "conflicts": conflicts,
+            "descending": descending,
+            "feed": feed,
+            "filter": filter,
+            "heartbeat": heartbeat,
+            "include_docs": include_docs,
+            "attachments": attachments,
+            "att_encoding_info": att_encoding_info,
+            "limit": limit,
+            "since": since,
+            "style": style,
+            "timeout": timeout,
+            "view": view,
+            "seq_interval": seq_interval,
+        }
+        if doc_ids is not None:
+            query_kwargs["filter"] = "_doc_ids"
+            return self._post(
+                resource="_changes",
+                body={"doc_ids": doc_ids},
+                query_kwargs=query_kwargs,
+            ).json()
+        if selector is not None:
+            query_kwargs["filter"] = "_selector"
+            return self._post(
+                resource="_changes",
+                body={"selector": selector},
+                query_kwargs=query_kwargs,
+            ).json()
+        return self._get(resource="_changes", query_kwargs=query_kwargs).json()
+
     def get_partition(self, partition_id: str) -> Partition:
         """
         Get a given partition.

--- a/src/couchdb3/sync/database.py
+++ b/src/couchdb3/sync/database.py
@@ -1237,9 +1237,7 @@ class Database(Base):
                 "in a future release."
             )
         if doc_ids is not None and selector is not None:
-            raise CouchDBError(
-                "Arguments 'doc_ids' and 'selector' are mutually exclusive."
-            )
+            raise CouchDBError("Arguments 'doc_ids' and 'selector' are mutually exclusive.")
         query_kwargs = {
             "conflicts": conflicts,
             "descending": descending,

--- a/src/couchdb3/sync/server.py
+++ b/src/couchdb3/sync/server.py
@@ -442,6 +442,259 @@ class Server(Base):
             ),
         ).json()
 
+    def membership(self) -> dict:
+        """
+        Displays the nodes that are part of the cluster.
+
+        Returns
+        -------
+        dict : A dictionary with the following keys.
+
+          - ``all_nodes`` (`list[str]`) — all nodes this node knows about
+          - ``cluster_nodes`` (`list[str]`) — nodes that are part of the cluster
+        """
+        return self._get(resource="_membership").json()
+
+    def cluster_setup(
+        self,
+        *,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -> dict:
+        """
+        Returns the status of the node or cluster, per the cluster setup wizard.
+
+        Parameters
+        ----------
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist on the node/cluster.
+            Defaults to ``["_users", "_replicator"]``.
+
+        Returns
+        -------
+        dict : A dictionary with a single key ``state`` whose value is one of
+        ``'cluster_disabled'``, ``'single_node_disabled'``, ``'single_node_enabled'``,
+        ``'cluster_enabled'``, or ``'cluster_finished'``.
+        """
+        return self._get(
+            resource="_cluster_setup",
+            query_kwargs={"ensure_dbs_exist": ensure_dbs_exist},
+        ).json()
+
+    def setup_cluster(
+        self,
+        action: str,
+        *,
+        bind_address: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        port: int | None = None,
+        node_count: int | None = None,
+        remote_node: str | None = None,
+        remote_current_user: str | None = None,
+        remote_current_password: str | None = None,
+        host: str | None = None,
+        ensure_dbs_exist: list[str] | None = None,
+    ) -> dict:
+        """
+        Configure a node as a single (standalone) node, as part of a cluster, or finalise
+        a cluster. This is a **destructive** operation — do not run against a shared or
+        production CouchDB instance during testing.
+
+        Parameters
+        ----------
+        action : str
+            One of ``'enable_single_node'``, ``'enable_cluster'``, ``'add_node'``, or
+            ``'finish_cluster'``.
+        bind_address : str
+            IP address to bind the current node. Use ``'0.0.0.0'`` to bind all interfaces.
+            (``enable_cluster`` and ``enable_single_node`` only)
+        username : str
+            Server-level administrator username to create, or the remote server's
+            administrator username (``add_node``).
+        password : str
+            Server-level administrator password to create, or the remote server's password
+            (``add_node``).
+        port : int
+            TCP port for this node (``enable_cluster`` / ``enable_single_node``) or the
+            remote node's port (``add_node``).
+        node_count : int
+            Total number of nodes to join into the cluster. Determines ``n`` (max 3).
+            (``enable_cluster`` only)
+        remote_node : str
+            IP address of the remote node. (``enable_cluster`` only)
+        remote_current_user : str
+            Username of the admin on the remote node. (``enable_cluster`` only)
+        remote_current_password : str
+            Password of the admin on the remote node. (``enable_cluster`` only)
+        host : str
+            Remote node IP to add to the cluster. (``add_node`` only)
+        ensure_dbs_exist : list[str]
+            List of system databases to ensure exist. Defaults to
+            ``["_users", "_replicator"]``.
+
+        Returns
+        -------
+        dict : ``{"ok": true}`` on success.
+        """
+        return self._post(
+            resource="_cluster_setup",
+            body=rm_nones_from_dict(
+                {
+                    "action": action,
+                    "bind_address": bind_address,
+                    "username": username,
+                    "password": password,
+                    "port": port,
+                    "node_count": node_count,
+                    "remote_node": remote_node,
+                    "remote_current_user": remote_current_user,
+                    "remote_current_password": remote_current_password,
+                    "host": host,
+                    "ensure_dbs_exist": ensure_dbs_exist,
+                }
+            ),
+        ).json()
+
+    def node_config(
+        self,
+        node: str = "_local",
+        section: str | None = None,
+        key: str | None = None,
+    ) -> dict | str:
+        """
+        Returns CouchDB node configuration.
+
+        - No `section` / `key` → full configuration tree (`dict`)
+        - `section` only → configuration section (`dict`)
+        - `section` + `key` → single configuration value (`str` or primitive)
+
+        The literal string ``'_local'`` (default) is an alias for the local node name.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+        section : str
+            Configuration section name (e.g. ``'log'``, ``'couchdb'``).
+        key : str
+            Configuration key within the section (e.g. ``'level'``).
+
+        Returns
+        -------
+        dict | str
+        """
+        resource = f"_node/{node}/_config"
+        if section:
+            resource = f"{resource}/{section}"
+            if key:
+                resource = f"{resource}/{key}"
+        return self._get(resource=resource).json()
+
+    def set_node_config(
+        self,
+        section: str,
+        key: str,
+        value: str,
+        node: str = "_local",
+    ) -> str:
+        """
+        Updates a single configuration value on a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        value : str
+            New value (must be a valid JSON string).
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        str : The previous value of the configuration key.
+        """
+        return self._put(
+            resource=f"_node/{node}/_config/{section}/{key}",
+            body=value,
+        ).json()
+
+    def delete_node_config(
+        self,
+        section: str,
+        key: str,
+        node: str = "_local",
+    ) -> str:
+        """
+        Deletes a single configuration value from a node. Returns the **old** value.
+
+        Parameters
+        ----------
+        section : str
+            Configuration section name.
+        key : str
+            Configuration key name.
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        str : The deleted value.
+        """
+        return self._delete(
+            resource=f"_node/{node}/_config/{section}/{key}",
+        ).json()
+
+    def reload_node_config(self, node: str = "_local") -> bool:
+        """
+        Reloads the configuration from disk. Flushes any in-memory configuration changes
+        that have not been written to disk.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        bool : ``True`` on success.
+        """
+        return self._post(
+            resource=f"_node/{node}/_config/_reload",
+            body={},
+        ).json().get("ok", False)
+
+    def node_stats(self, node: str = "_local") -> dict:
+        """
+        Returns statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        dict
+        """
+        return self._get(resource=f"_node/{node}/_stats").json()
+
+    def node_system(self, node: str = "_local") -> dict:
+        """
+        Returns system-level statistics for the specified node.
+
+        Parameters
+        ----------
+        node : str
+            Node name. Default ``'_local'``.
+
+        Returns
+        -------
+        dict
+        """
+        return self._get(resource=f"_node/{node}/_system").json()
+
     def up(
         self,
         raise_exception: bool = False,

--- a/src/couchdb3/sync/server.py
+++ b/src/couchdb3/sync/server.py
@@ -660,10 +660,14 @@ class Server(Base):
         -------
         bool : ``True`` on success.
         """
-        return self._post(
-            resource=f"_node/{node}/_config/_reload",
-            body={},
-        ).json().get("ok", False)
+        return (
+            self._post(
+                resource=f"_node/{node}/_config/_reload",
+                body={},
+            )
+            .json()
+            .get("ok", False)
+        )
 
     def node_stats(self, node: str = "_local") -> dict:
         """

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -256,6 +256,83 @@ class TestAsyncPartition(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(self.partition, AsyncPartition)
 
 
+class TestAsyncDatabaseChanges(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = AsyncServer(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
+        all_dbs = await self.server.all_dbs()
+        if DB_NAME in all_dbs:
+            self.db = await self.server.get(DB_NAME)
+        else:
+            self.db = await self.server.create(DB_NAME)
+
+    async def asyncTearDown(self):
+        await self.server.aclose()
+
+    async def test_changes_normal(self):
+        docs = [
+            {"_id": f"test-async-changes-doc-{i}", "type": "async-changes-test"}
+            for i in range(3)
+        ]
+        await self.db.bulk_docs(docs=docs)
+        result = await self.db.changes()
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("last_seq", result)
+        self.assertIsInstance(result["results"], list)
+
+    async def test_changes_since(self):
+        before = await self.db.changes(since="now")
+        last_seq = before["last_seq"]
+        new_doc = {"_id": "test-async-changes-since-doc", "type": "async-changes-since"}
+        await self.db.create(new_doc)
+        result = await self.db.changes(since=last_seq)
+        ids = [r["id"] for r in result["results"]]
+        self.assertIn("test-async-changes-since-doc", ids)
+
+    async def test_changes_doc_ids(self):
+        target_id = "test-async-changes-doc-ids-doc"
+        await self.db.create({"_id": target_id, "type": "async-changes-doc-ids"})
+        result = await self.db.changes(doc_ids=[target_id])
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        ids = [r["id"] for r in result["results"]]
+        self.assertIn(target_id, ids)
+
+    async def test_changes_include_docs(self):
+        doc_id = "test-async-changes-include-docs-doc"
+        if not await self.db.get(doc_id):
+            await self.db.create({"_id": doc_id, "type": "async-changes-include-docs"})
+        result = await self.db.changes(doc_ids=[doc_id], include_docs=True)
+        self.assertIsInstance(result, dict)
+        for row in result["results"]:
+            if row["id"] == doc_id:
+                self.assertIn("doc", row)
+                break
+        else:
+            self.fail(f"Doc '{doc_id}' not found in changes results")
+
+    async def test_changes_selector(self):
+        await self.db.create(
+            {"_id": "test-async-changes-selector-doc", "type": "async-changes-selector-unique"}
+        )
+        result = await self.db.changes(
+            selector={"type": {"$eq": "async-changes-selector-unique"}}
+        )
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+
+    async def test_changes_invalid_feed_raises(self):
+        with self.assertRaises(ValueError):
+            await self.db.changes(feed="continuous")
+        with self.assertRaises(ValueError):
+            await self.db.changes(feed="eventsource")
+
+    async def test_changes_mutual_exclusion_raises(self):
+        from couchdb3.exceptions import CouchDBError
+        with self.assertRaises(CouchDBError):
+            await self.db.changes(doc_ids=["a"], selector={"type": "x"})
+
+
 @atexit.register
 def rm_test_dbs() -> None:
     """Remove temporary async database test DBs using the sync client."""

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -270,8 +270,7 @@ class TestAsyncDatabaseChanges(unittest.IsolatedAsyncioTestCase):
 
     async def test_changes_normal(self):
         docs = [
-            {"_id": f"test-async-changes-doc-{i}", "type": "async-changes-test"}
-            for i in range(3)
+            {"_id": f"test-async-changes-doc-{i}", "type": "async-changes-test"} for i in range(3)
         ]
         await self.db.bulk_docs(docs=docs)
         result = await self.db.changes()
@@ -315,9 +314,7 @@ class TestAsyncDatabaseChanges(unittest.IsolatedAsyncioTestCase):
         await self.db.create(
             {"_id": "test-async-changes-selector-doc", "type": "async-changes-selector-unique"}
         )
-        result = await self.db.changes(
-            selector={"type": {"$eq": "async-changes-selector-unique"}}
-        )
+        result = await self.db.changes(selector={"type": {"$eq": "async-changes-selector-unique"}})
         self.assertIsInstance(result, dict)
         self.assertIn("results", result)
 
@@ -329,6 +326,7 @@ class TestAsyncDatabaseChanges(unittest.IsolatedAsyncioTestCase):
 
     async def test_changes_mutual_exclusion_raises(self):
         from couchdb3.exceptions import CouchDBError
+
         with self.assertRaises(CouchDBError):
             await self.db.changes(doc_ids=["a"], selector={"type": "x"})
 

--- a/tests/test_async_server.py
+++ b/tests/test_async_server.py
@@ -113,6 +113,75 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
             self.assertIsInstance(client, AsyncServer)
             self.assertTrue(await client.up())
 
+    async def test_membership(self):
+        result = await self.client.membership()
+        self.assertIsInstance(result, dict)
+        self.assertIn("all_nodes", result)
+        self.assertIn("cluster_nodes", result)
+        self.assertIsInstance(result["all_nodes"], list)
+        self.assertIsInstance(result["cluster_nodes"], list)
+
+    async def test_cluster_setup(self):
+        result = await self.client.cluster_setup()
+        self.assertIsInstance(result, dict)
+        self.assertIn("state", result)
+        valid_states = {
+            "cluster_disabled",
+            "single_node_disabled",
+            "single_node_enabled",
+            "cluster_enabled",
+            "cluster_finished",
+        }
+        self.assertIn(result["state"], valid_states)
+
+    @unittest.skip("requires isolated CouchDB cluster — destructive operation")
+    async def test_setup_cluster(self):
+        # Contract: POST /_cluster_setup returns {"ok": true}
+        result = await self.client.setup_cluster(
+            action="enable_single_node",
+            bind_address="127.0.0.1",
+            username="admin",
+            password="secret",
+            port=5984,
+            ensure_dbs_exist=["_users", "_replicator"],
+        )
+        self.assertTrue(result.get("ok"))
+
+    async def test_node_config_full(self):
+        result = await self.client.node_config()
+        self.assertIsInstance(result, dict)
+        self.assertIn("couchdb", result)
+
+    async def test_node_config_section(self):
+        result = await self.client.node_config(section="couchdb")
+        self.assertIsInstance(result, dict)
+
+    async def test_node_config_key(self):
+        result = await self.client.node_config(section="chttpd", key="bind_address")
+        self.assertIsInstance(result, str)
+
+    async def test_set_and_delete_node_config(self):
+        section = "couchdb"
+        key = "test_opencode_async_key"
+        value = "test_async_value"
+        await self.client.set_node_config(section=section, key=key, value=value)
+        got = await self.client.node_config(section=section, key=key)
+        self.assertEqual(got, value)
+        deleted = await self.client.delete_node_config(section=section, key=key)
+        self.assertEqual(deleted, value)
+
+    async def test_reload_node_config(self):
+        result = await self.client.reload_node_config()
+        self.assertTrue(result)
+
+    async def test_node_stats(self):
+        result = await self.client.node_stats()
+        self.assertIsInstance(result, dict)
+
+    async def test_node_system(self):
+        result = await self.client.node_system()
+        self.assertIsInstance(result, dict)
+
 
 @atexit.register
 def rm_test_dbs() -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -387,6 +387,67 @@ class TestDatabase(unittest.TestCase):
         partition = DB_PARTITIONED.get_partition("p0")
         self.assertIsInstance(partition, Partition)
 
+    def test_changes_normal(self):
+        docs = [
+            {"_id": f"test-changes-doc-{i}", "type": "changes-test"}
+            for i in range(3)
+        ]
+        DB.bulk_docs(docs=docs)
+        result = DB.changes()
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        self.assertIn("last_seq", result)
+        self.assertIsInstance(result["results"], list)
+
+    def test_changes_since(self):
+        # Capture the current sequence before creating the doc
+        before = DB.changes(since="now")
+        last_seq = before["last_seq"]
+        new_doc = {"_id": "test-changes-since-doc", "type": "changes-since"}
+        DB.create(new_doc)
+        result = DB.changes(since=last_seq)
+        ids = [r["id"] for r in result["results"]]
+        self.assertIn("test-changes-since-doc", ids)
+
+    def test_changes_doc_ids(self):
+        target_id = "test-changes-doc-ids-doc"
+        DB.create({"_id": target_id, "type": "changes-doc-ids"})
+        result = DB.changes(doc_ids=[target_id])
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+        ids = [r["id"] for r in result["results"]]
+        self.assertIn(target_id, ids)
+
+    def test_changes_include_docs(self):
+        doc_id = "test-changes-include-docs-doc"
+        if doc_id not in DB:
+            DB.create({"_id": doc_id, "type": "changes-include-docs"})
+        result = DB.changes(doc_ids=[doc_id], include_docs=True)
+        self.assertIsInstance(result, dict)
+        for row in result["results"]:
+            if row["id"] == doc_id:
+                self.assertIn("doc", row)
+                break
+        else:
+            self.fail(f"Doc '{doc_id}' not found in changes results")
+
+    def test_changes_selector(self):
+        DB.create({"_id": "test-changes-selector-doc", "type": "changes-selector-unique"})
+        result = DB.changes(selector={"type": {"$eq": "changes-selector-unique"}})
+        self.assertIsInstance(result, dict)
+        self.assertIn("results", result)
+
+    def test_changes_invalid_feed_raises(self):
+        with self.assertRaises(ValueError):
+            DB.changes(feed="continuous")
+        with self.assertRaises(ValueError):
+            DB.changes(feed="eventsource")
+
+    def test_changes_mutual_exclusion_raises(self):
+        from couchdb3.exceptions import CouchDBError
+        with self.assertRaises(CouchDBError):
+            DB.changes(doc_ids=["a"], selector={"type": "x"})
+
 
 @atexit.register
 def rm_test_db() -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -388,10 +388,7 @@ class TestDatabase(unittest.TestCase):
         self.assertIsInstance(partition, Partition)
 
     def test_changes_normal(self):
-        docs = [
-            {"_id": f"test-changes-doc-{i}", "type": "changes-test"}
-            for i in range(3)
-        ]
+        docs = [{"_id": f"test-changes-doc-{i}", "type": "changes-test"} for i in range(3)]
         DB.bulk_docs(docs=docs)
         result = DB.changes()
         self.assertIsInstance(result, dict)
@@ -445,6 +442,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_changes_mutual_exclusion_raises(self):
         from couchdb3.exceptions import CouchDBError
+
         with self.assertRaises(CouchDBError):
             DB.changes(doc_ids=["a"], selector={"type": "x"})
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,6 +91,81 @@ class TestClient(unittest.TestCase):
         with Server(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD) as client:
             self.assertIsInstance(client, Server)
 
+    def test_membership(self):
+        result = CLIENT.membership()
+        self.assertIsInstance(result, dict)
+        self.assertIn("all_nodes", result)
+        self.assertIn("cluster_nodes", result)
+        self.assertIsInstance(result["all_nodes"], list)
+        self.assertIsInstance(result["cluster_nodes"], list)
+
+    def test_cluster_setup(self):
+        result = CLIENT.cluster_setup()
+        self.assertIsInstance(result, dict)
+        self.assertIn("state", result)
+        valid_states = {
+            "cluster_disabled",
+            "single_node_disabled",
+            "single_node_enabled",
+            "cluster_enabled",
+            "cluster_finished",
+        }
+        self.assertIn(result["state"], valid_states)
+
+    @unittest.skip("requires isolated CouchDB cluster — destructive operation")
+    def test_setup_cluster(self):
+        # Contract: POST /_cluster_setup returns {"ok": true}
+        # action must be one of: enable_single_node, enable_cluster, add_node, finish_cluster
+        result = CLIENT.setup_cluster(
+            action="enable_single_node",
+            bind_address="127.0.0.1",
+            username="admin",
+            password="secret",
+            port=5984,
+            ensure_dbs_exist=["_users", "_replicator"],
+        )
+        self.assertTrue(result.get("ok"))
+
+    def test_node_config_full(self):
+        result = CLIENT.node_config()
+        self.assertIsInstance(result, dict)
+        # CouchDB always has at least these top-level sections
+        self.assertIn("couchdb", result)
+
+    def test_node_config_section(self):
+        result = CLIENT.node_config(section="couchdb")
+        self.assertIsInstance(result, dict)
+
+    def test_node_config_key(self):
+        result = CLIENT.node_config(section="chttpd", key="bind_address")
+        # Returns a raw string value
+        self.assertIsInstance(result, str)
+
+    def test_set_and_delete_node_config(self):
+        section = "couchdb"
+        key = "test_opencode_key"
+        value = "test_value"
+        # Set a new key — old value is None (missing key) so CouchDB returns ""
+        CLIENT.set_node_config(section=section, key=key, value=value)
+        # Confirm it was set
+        got = CLIENT.node_config(section=section, key=key)
+        self.assertEqual(got, value)
+        # Delete it — returns old value
+        deleted = CLIENT.delete_node_config(section=section, key=key)
+        self.assertEqual(deleted, value)
+
+    def test_reload_node_config(self):
+        result = CLIENT.reload_node_config()
+        self.assertTrue(result)
+
+    def test_node_stats(self):
+        result = CLIENT.node_stats()
+        self.assertIsInstance(result, dict)
+
+    def test_node_system(self):
+        result = CLIENT.node_system()
+        self.assertIsInstance(result, dict)
+
 
 @atexit.register
 def rm_test_db() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "couchdb3"
-version = "3.2.1"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Implements the first batch of missing CouchDB API coverage tracked in `TODO.md` and the new `.opencode/skills/couchdb3-api-coverage/SKILL.md` tracker.

## New methods

### `Database` / `AsyncDatabase`

| Method | Endpoint | Notes |
|---|---|---|
| `changes()` | `GET` / `POST /{db}/_changes` | `normal` + `longpoll` feeds; auto-dispatches to POST for `doc_ids` (`_doc_ids` filter) and `selector` (`_selector` filter). `continuous`/`eventsource` raise `ValueError` with a clear message. |

### `Server` / `AsyncServer`

| Method | Endpoint |
|---|---|
| `membership()` | `GET /_membership` |
| `cluster_setup()` | `GET /_cluster_setup` |
| `setup_cluster(action, **kwargs)` | `POST /_cluster_setup` |
| `node_config(node, section, key)` | `GET /_node/{node}/_config[/{section}[/{key}]]` |
| `set_node_config(section, key, value, node)` | `PUT /_node/{node}/_config/{section}/{key}` |
| `delete_node_config(section, key, node)` | `DELETE /_node/{node}/_config/{section}/{key}` |
| `reload_node_config(node)` | `POST /_node/{node}/_config/_reload` |
| `node_stats(node)` | `GET /_node/{node}/_stats` |
| `node_system(node)` | `GET /_node/{node}/_system` |

All `node_*` methods default to `node="_local"` so they work on single-node setups without knowing the node name.

## Tests

- **112 pass, 2 skipped** (the 2 skips are `test_setup_cluster` in both sync and async test files — the `POST /_cluster_setup` action is destructive and intentionally skipped with `@unittest.skip` on shared/CI instances)
- New test classes: `TestDatabase.test_changes_*`, `TestAsyncDatabaseChanges`, plus server/async-server tests for all new methods

## Other

- `ruff format` applied to all modified files
- Docs regenerated via `make html`
- Version bumped `3.2.1` → `3.3.0` (`pyproject.toml`, `setup.py`, `uv.lock`)
- `.opencode/skills/couchdb3-api-coverage/SKILL.md` added as a living tracker for implemented vs pending API endpoints
- `TODO.md` updated — completed items struck through