### PR TITLE
fix: anchor Database/Partition lifetime to owning Server/Database — add .server/.database properties (v3.3.1)

### DIFF
--- a/docs/aio/async_database.html
+++ b/docs/aio/async_database.html
@@ -75,6 +75,7 @@ el.replaceWith(d);
         auth_method: str | None = None,
         timeout: int | None = DEFAULT_TIMEOUT,
         session: httpx.AsyncClient | None = None,
+        _server: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
@@ -104,6 +105,11 @@ el.replaceWith(d);
         session : httpx.AsyncClient
             A specific async client to use. Optional — if not provided, a new client will be
             initialized.
+        _server : AsyncServer
+            The owning `AsyncServer` instance. Set internally by `AsyncServer.get()` to keep
+            the server alive for the lifetime of this database object. Not part of the public
+            constructor API — pass `None` (default) when constructing an `AsyncDatabase`
+            directly.
         &#34;&#34;&#34;
         super().__init__(
             url=url,
@@ -122,6 +128,21 @@ el.replaceWith(d);
             )
         self.name = name
         self.root = name
+        self._server = _server
+
+    @property
+    def server(self):
+        &#34;&#34;&#34;
+        The `AsyncServer` instance this database was obtained from, or `None` if the database
+        was constructed directly (i.e. not via `AsyncServer.get()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        AsyncServer | None
+        &#34;&#34;&#34;
+        return self._server
 
     def __repr__(self) -&gt; str:
         &#34;&#34;&#34;
@@ -1177,6 +1198,7 @@ el.replaceWith(d);
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,  # shared — child sets _owns_session=False
+            _database=self,
         )</code></pre>
 </details>
 <div class="desc"><p>Async CouchDB database client. Mirrors <code>Database</code> with <code>async def</code> methods throughout.</p>
@@ -1208,6 +1230,11 @@ Default is <code><a title="couchdb3.utils.DEFAULT_AUTH_METHOD" href="../utils.ht
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.AsyncClient</code></dt>
 <dd>A specific async client to use. Optional — if not provided, a new client will be
 initialized.</dd>
+<dt><strong><code>_server</code></strong> :&ensp;<code>AsyncServer</code></dt>
+<dd>The owning <code>AsyncServer</code> instance. Set internally by <code>AsyncServer.get()</code> to keep
+the server alive for the lifetime of this database object. Not part of the public
+constructor API — pass <code>None</code> (default) when constructing an <code><a title="couchdb3.aio.async_database.AsyncDatabase" href="#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></code>
+directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1217,6 +1244,38 @@ initialized.</dd>
 <ul class="hlist">
 <li><a title="couchdb3.aio.async_database.AsyncPartition" href="#couchdb3.aio.async_database.AsyncPartition">AsyncPartition</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.aio.async_database.AsyncDatabase.server"><code class="name">prop <span class="ident">server</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def server(self):
+    &#34;&#34;&#34;
+    The `AsyncServer` instance this database was obtained from, or `None` if the database
+    was constructed directly (i.e. not via `AsyncServer.get()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    AsyncServer | None
+    &#34;&#34;&#34;
+    return self._server</code></pre>
+</details>
+<div class="desc"><p>The <code>AsyncServer</code> instance this database was obtained from, or <code>None</code> if the database
+was constructed directly (i.e. not via <code>AsyncServer.get()</code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>AsyncServer | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.aio.async_database.AsyncDatabase.all_docs"><code class="name flex">
@@ -2322,6 +2381,7 @@ Default <code>None</code>.</dd>
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,  # shared — child sets _owns_session=False
+        _database=self,
     )</code></pre>
 </details>
 <div class="desc"><p>Get a given partition.</p>
@@ -3017,6 +3077,7 @@ Default <code>None</code>.</dd>
         auth_method: str | None = None,
         timeout: int | None = None,
         session: httpx.AsyncClient | None = None,
+        _database: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
@@ -3042,6 +3103,11 @@ Default <code>None</code>.</dd>
             The default timeout for requests. Default `None`.
         session : httpx.AsyncClient
             A specific async client to use. Optional.
+        _database : AsyncDatabase
+            The owning `AsyncDatabase` instance. Set internally by
+            `AsyncDatabase.get_partition()` to keep the database alive for the lifetime of
+            this partition object. Not part of the public constructor API — pass `None`
+            (default) when constructing an `AsyncPartition` directly.
         &#34;&#34;&#34;
         super().__init__(
             name=name,
@@ -3055,6 +3121,21 @@ Default <code>None</code>.</dd>
             timeout=timeout,
         )
         self.partition_id = partition_id
+        self._database = _database
+
+    @property
+    def database(self):
+        &#34;&#34;&#34;
+        The `AsyncDatabase` instance this partition was obtained from, or `None` if the
+        partition was constructed directly (i.e. not via `AsyncDatabase.get_partition()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        AsyncDatabase | None
+        &#34;&#34;&#34;
+        return self._database
 
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
@@ -3358,12 +3439,49 @@ Default <code>None</code>.</dd>
 <dd>The default timeout for requests. Default <code>None</code>.</dd>
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.AsyncClient</code></dt>
 <dd>A specific async client to use. Optional.</dd>
+<dt><strong><code>_database</code></strong> :&ensp;<code><a title="couchdb3.aio.async_database.AsyncDatabase" href="#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></code></dt>
+<dd>The owning <code><a title="couchdb3.aio.async_database.AsyncDatabase" href="#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></code> instance. Set internally by
+<code><a title="couchdb3.aio.async_database.AsyncDatabase.get_partition" href="#couchdb3.aio.async_database.AsyncDatabase.get_partition">AsyncDatabase.get_partition()</a></code> to keep the database alive for the lifetime of
+this partition object. Not part of the public constructor API — pass <code>None</code>
+(default) when constructing an <code><a title="couchdb3.aio.async_database.AsyncPartition" href="#couchdb3.aio.async_database.AsyncPartition">AsyncPartition</a></code> directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="couchdb3.aio.async_database.AsyncDatabase" href="#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></li>
 <li><a title="couchdb3.aio.async_base.AsyncBase" href="async_base.html#couchdb3.aio.async_base.AsyncBase">AsyncBase</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.aio.async_database.AsyncPartition.database"><code class="name">prop <span class="ident">database</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def database(self):
+    &#34;&#34;&#34;
+    The `AsyncDatabase` instance this partition was obtained from, or `None` if the
+    partition was constructed directly (i.e. not via `AsyncDatabase.get_partition()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    AsyncDatabase | None
+    &#34;&#34;&#34;
+    return self._database</code></pre>
+</details>
+<div class="desc"><p>The <code><a title="couchdb3.aio.async_database.AsyncDatabase" href="#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></code> instance this partition was obtained from, or <code>None</code> if the
+partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.async_database.AsyncDatabase.get_partition" href="#couchdb3.aio.async_database.AsyncDatabase.get_partition">AsyncDatabase.get_partition()</a></code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>AsyncDatabase | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.aio.async_database.AsyncPartition.add_partition_to_doc"><code class="name flex">
@@ -3846,6 +3964,7 @@ Default <code>None</code>.</dd>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.put_design" href="#couchdb3.aio.async_database.AsyncDatabase.put_design">put_design</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.save_index" href="#couchdb3.aio.async_database.AsyncDatabase.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.security" href="#couchdb3.aio.async_database.AsyncDatabase.security">security</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.server" href="#couchdb3.aio.async_database.AsyncDatabase.server">server</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.update_security" href="#couchdb3.aio.async_database.AsyncDatabase.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.url" href="async_base.html#couchdb3.aio.async_base.AsyncBase.url">url</a></code></li>
 </ul>
@@ -3892,6 +4011,7 @@ Default <code>None</code>.</dd>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.save" href="#couchdb3.aio.async_database.AsyncDatabase.save">save</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.save_index" href="#couchdb3.aio.async_database.AsyncDatabase.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.security" href="#couchdb3.aio.async_database.AsyncDatabase.security">security</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.server" href="#couchdb3.aio.async_database.AsyncDatabase.server">server</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.update_security" href="#couchdb3.aio.async_database.AsyncDatabase.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.view" href="#couchdb3.aio.async_database.AsyncDatabase.view">view</a></code></li>
 </ul>
@@ -3906,6 +4026,7 @@ Default <code>None</code>.</dd>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.bulk_get" href="#couchdb3.aio.async_database.AsyncPartition.bulk_get">bulk_get</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.copy" href="#couchdb3.aio.async_database.AsyncPartition.copy">copy</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.create" href="#couchdb3.aio.async_database.AsyncPartition.create">create</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncPartition.database" href="#couchdb3.aio.async_database.AsyncPartition.database">database</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.delete" href="#couchdb3.aio.async_database.AsyncPartition.delete">delete</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.delete_attachment" href="#couchdb3.aio.async_database.AsyncPartition.delete_attachment">delete_attachment</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.find" href="#couchdb3.aio.async_database.AsyncPartition.find">find</a></code></li>

--- a/docs/aio/async_server.html
+++ b/docs/aio/async_server.html
@@ -339,6 +339,7 @@ el.replaceWith(d);
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,  # shared — child sets _owns_session=False
+            _server=self,
         )
         try:
             await db._head()
@@ -1157,6 +1158,7 @@ Defaults to <code>["_users", "_replicator"]</code>.</dd>
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,  # shared — child sets _owns_session=False
+        _server=self,
     )
     try:
         await db._head()

--- a/docs/aio/index.html
+++ b/docs/aio/index.html
@@ -95,6 +95,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         auth_method: str | None = None,
         timeout: int | None = DEFAULT_TIMEOUT,
         session: httpx.AsyncClient | None = None,
+        _server: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
@@ -124,6 +125,11 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         session : httpx.AsyncClient
             A specific async client to use. Optional — if not provided, a new client will be
             initialized.
+        _server : AsyncServer
+            The owning `AsyncServer` instance. Set internally by `AsyncServer.get()` to keep
+            the server alive for the lifetime of this database object. Not part of the public
+            constructor API — pass `None` (default) when constructing an `AsyncDatabase`
+            directly.
         &#34;&#34;&#34;
         super().__init__(
             url=url,
@@ -142,6 +148,21 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             )
         self.name = name
         self.root = name
+        self._server = _server
+
+    @property
+    def server(self):
+        &#34;&#34;&#34;
+        The `AsyncServer` instance this database was obtained from, or `None` if the database
+        was constructed directly (i.e. not via `AsyncServer.get()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        AsyncServer | None
+        &#34;&#34;&#34;
+        return self._server
 
     def __repr__(self) -&gt; str:
         &#34;&#34;&#34;
@@ -1197,6 +1218,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,  # shared — child sets _owns_session=False
+            _database=self,
         )</code></pre>
 </details>
 <div class="desc"><p>Async CouchDB database client. Mirrors <code>Database</code> with <code>async def</code> methods throughout.</p>
@@ -1228,6 +1250,11 @@ Default is <code><a title="couchdb3.utils.DEFAULT_AUTH_METHOD" href="../utils.ht
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.AsyncClient</code></dt>
 <dd>A specific async client to use. Optional — if not provided, a new client will be
 initialized.</dd>
+<dt><strong><code>_server</code></strong> :&ensp;<code><a title="couchdb3.aio.AsyncServer" href="#couchdb3.aio.AsyncServer">AsyncServer</a></code></dt>
+<dd>The owning <code><a title="couchdb3.aio.AsyncServer" href="#couchdb3.aio.AsyncServer">AsyncServer</a></code> instance. Set internally by <code><a title="couchdb3.aio.AsyncServer.get" href="#couchdb3.aio.AsyncServer.get">AsyncServer.get()</a></code> to keep
+the server alive for the lifetime of this database object. Not part of the public
+constructor API — pass <code>None</code> (default) when constructing an <code><a title="couchdb3.aio.AsyncDatabase" href="#couchdb3.aio.AsyncDatabase">AsyncDatabase</a></code>
+directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1237,6 +1264,38 @@ initialized.</dd>
 <ul class="hlist">
 <li><a title="couchdb3.aio.async_database.AsyncPartition" href="async_database.html#couchdb3.aio.async_database.AsyncPartition">AsyncPartition</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.aio.AsyncDatabase.server"><code class="name">prop <span class="ident">server</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def server(self):
+    &#34;&#34;&#34;
+    The `AsyncServer` instance this database was obtained from, or `None` if the database
+    was constructed directly (i.e. not via `AsyncServer.get()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    AsyncServer | None
+    &#34;&#34;&#34;
+    return self._server</code></pre>
+</details>
+<div class="desc"><p>The <code><a title="couchdb3.aio.AsyncServer" href="#couchdb3.aio.AsyncServer">AsyncServer</a></code> instance this database was obtained from, or <code>None</code> if the database
+was constructed directly (i.e. not via <code><a title="couchdb3.aio.AsyncServer.get" href="#couchdb3.aio.AsyncServer.get">AsyncServer.get()</a></code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>AsyncServer | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.aio.AsyncDatabase.all_docs"><code class="name flex">
@@ -2342,6 +2401,7 @@ Default <code>None</code>.</dd>
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,  # shared — child sets _owns_session=False
+        _database=self,
     )</code></pre>
 </details>
 <div class="desc"><p>Get a given partition.</p>
@@ -3037,6 +3097,7 @@ Default <code>None</code>.</dd>
         auth_method: str | None = None,
         timeout: int | None = None,
         session: httpx.AsyncClient | None = None,
+        _database: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
@@ -3062,6 +3123,11 @@ Default <code>None</code>.</dd>
             The default timeout for requests. Default `None`.
         session : httpx.AsyncClient
             A specific async client to use. Optional.
+        _database : AsyncDatabase
+            The owning `AsyncDatabase` instance. Set internally by
+            `AsyncDatabase.get_partition()` to keep the database alive for the lifetime of
+            this partition object. Not part of the public constructor API — pass `None`
+            (default) when constructing an `AsyncPartition` directly.
         &#34;&#34;&#34;
         super().__init__(
             name=name,
@@ -3075,6 +3141,21 @@ Default <code>None</code>.</dd>
             timeout=timeout,
         )
         self.partition_id = partition_id
+        self._database = _database
+
+    @property
+    def database(self):
+        &#34;&#34;&#34;
+        The `AsyncDatabase` instance this partition was obtained from, or `None` if the
+        partition was constructed directly (i.e. not via `AsyncDatabase.get_partition()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        AsyncDatabase | None
+        &#34;&#34;&#34;
+        return self._database
 
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
@@ -3378,12 +3459,49 @@ Default <code>None</code>.</dd>
 <dd>The default timeout for requests. Default <code>None</code>.</dd>
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.AsyncClient</code></dt>
 <dd>A specific async client to use. Optional.</dd>
+<dt><strong><code>_database</code></strong> :&ensp;<code><a title="couchdb3.aio.AsyncDatabase" href="#couchdb3.aio.AsyncDatabase">AsyncDatabase</a></code></dt>
+<dd>The owning <code><a title="couchdb3.aio.AsyncDatabase" href="#couchdb3.aio.AsyncDatabase">AsyncDatabase</a></code> instance. Set internally by
+<code><a title="couchdb3.aio.AsyncDatabase.get_partition" href="#couchdb3.aio.AsyncDatabase.get_partition">AsyncDatabase.get_partition()</a></code> to keep the database alive for the lifetime of
+this partition object. Not part of the public constructor API — pass <code>None</code>
+(default) when constructing an <code><a title="couchdb3.aio.AsyncPartition" href="#couchdb3.aio.AsyncPartition">AsyncPartition</a></code> directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="couchdb3.aio.async_database.AsyncDatabase" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase">AsyncDatabase</a></li>
 <li><a title="couchdb3.aio.async_base.AsyncBase" href="async_base.html#couchdb3.aio.async_base.AsyncBase">AsyncBase</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.aio.AsyncPartition.database"><code class="name">prop <span class="ident">database</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def database(self):
+    &#34;&#34;&#34;
+    The `AsyncDatabase` instance this partition was obtained from, or `None` if the
+    partition was constructed directly (i.e. not via `AsyncDatabase.get_partition()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    AsyncDatabase | None
+    &#34;&#34;&#34;
+    return self._database</code></pre>
+</details>
+<div class="desc"><p>The <code><a title="couchdb3.aio.AsyncDatabase" href="#couchdb3.aio.AsyncDatabase">AsyncDatabase</a></code> instance this partition was obtained from, or <code>None</code> if the
+partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.AsyncDatabase.get_partition" href="#couchdb3.aio.AsyncDatabase.get_partition">AsyncDatabase.get_partition()</a></code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>AsyncDatabase | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.aio.AsyncPartition.add_partition_to_doc"><code class="name flex">
@@ -3866,6 +3984,7 @@ Default <code>None</code>.</dd>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.put_design" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.put_design">put_design</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.save_index" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.security" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.security">security</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.server" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.server">server</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.update_security" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.url" href="async_base.html#couchdb3.aio.async_base.AsyncBase.url">url</a></code></li>
 </ul>
@@ -4165,6 +4284,7 @@ Default <code>None</code>.</dd>
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,  # shared — child sets _owns_session=False
+            _server=self,
         )
         try:
             await db._head()
@@ -4983,6 +5103,7 @@ Defaults to <code>["_users", "_replicator"]</code>.</dd>
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,  # shared — child sets _owns_session=False
+        _server=self,
     )
     try:
         await db._head()
@@ -5725,6 +5846,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.aio.AsyncDatabase.save" href="#couchdb3.aio.AsyncDatabase.save">save</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.save_index" href="#couchdb3.aio.AsyncDatabase.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.security" href="#couchdb3.aio.AsyncDatabase.security">security</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncDatabase.server" href="#couchdb3.aio.AsyncDatabase.server">server</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.update_security" href="#couchdb3.aio.AsyncDatabase.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.view" href="#couchdb3.aio.AsyncDatabase.view">view</a></code></li>
 </ul>
@@ -5739,6 +5861,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.aio.AsyncPartition.bulk_get" href="#couchdb3.aio.AsyncPartition.bulk_get">bulk_get</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.copy" href="#couchdb3.aio.AsyncPartition.copy">copy</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.create" href="#couchdb3.aio.AsyncPartition.create">create</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncPartition.database" href="#couchdb3.aio.AsyncPartition.database">database</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.delete" href="#couchdb3.aio.AsyncPartition.delete">delete</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.delete_attachment" href="#couchdb3.aio.AsyncPartition.delete_attachment">delete_attachment</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.find" href="#couchdb3.aio.AsyncPartition.find">find</a></code></li>

--- a/docs/sync/database.html
+++ b/docs/sync/database.html
@@ -72,6 +72,7 @@ el.replaceWith(d);
         auth_method: str | None = None,
         timeout: int | None = DEFAULT_TIMEOUT,
         session: httpx.Client | None = None,
+        _server: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
@@ -99,6 +100,10 @@ el.replaceWith(d);
             The default timeout for requests. Default c.f. `couchdb3.utils.DEFAULT_TIMEOUT`.
         session: httpx.Client
             A specific client to use. Optional - if not provided, a new client will be initialized.
+        _server : Server
+            The owning `Server` instance. Set internally by `Server.get()` to keep the server
+            alive for the lifetime of this database object. Not part of the public constructor
+            API — pass `None` (default) when constructing a `Database` directly.
         &#34;&#34;&#34;
         super().__init__(
             url=url,
@@ -117,6 +122,21 @@ el.replaceWith(d);
             )
         self.name = name
         self.root = name
+        self._server = _server
+
+    @property
+    def server(self):
+        &#34;&#34;&#34;
+        The `Server` instance this database was obtained from, or `None` if the database
+        was constructed directly (i.e. not via `Server.get()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        Server | None
+        &#34;&#34;&#34;
+        return self._server
 
     def __getitem__(self, item) -&gt; Document:
         return self.get(docid=item, check=True)
@@ -1318,6 +1338,7 @@ el.replaceWith(d);
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,
+            _database=self,
         )</code></pre>
 </details>
 <div class="desc"><p>Abstract Couchdb database</p>
@@ -1345,6 +1366,10 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <dd>The default timeout for requests. Default c.f. <code><a title="couchdb3.utils.DEFAULT_TIMEOUT" href="../utils.html#couchdb3.utils.DEFAULT_TIMEOUT">DEFAULT_TIMEOUT</a></code>.</dd>
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.Client</code></dt>
 <dd>A specific client to use. Optional - if not provided, a new client will be initialized.</dd>
+<dt><strong><code>_server</code></strong> :&ensp;<code>Server</code></dt>
+<dd>The owning <code>Server</code> instance. Set internally by <code>Server.get()</code> to keep the server
+alive for the lifetime of this database object. Not part of the public constructor
+API — pass <code>None</code> (default) when constructing a <code><a title="couchdb3.sync.database.Database" href="#couchdb3.sync.database.Database">Database</a></code> directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1354,6 +1379,38 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <ul class="hlist">
 <li><a title="couchdb3.sync.database.Partition" href="#couchdb3.sync.database.Partition">Partition</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.sync.database.Database.server"><code class="name">prop <span class="ident">server</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def server(self):
+    &#34;&#34;&#34;
+    The `Server` instance this database was obtained from, or `None` if the database
+    was constructed directly (i.e. not via `Server.get()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    Server | None
+    &#34;&#34;&#34;
+    return self._server</code></pre>
+</details>
+<div class="desc"><p>The <code>Server</code> instance this database was obtained from, or <code>None</code> if the database
+was constructed directly (i.e. not via <code>Server.get()</code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Server | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.sync.database.Database.all_docs"><code class="name flex">
@@ -2592,6 +2649,7 @@ revisions. Default <code>None</code>.</dd>
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,
+        _database=self,
     )</code></pre>
 </details>
 <div class="desc"><p>Get a given partition.</p>
@@ -3422,11 +3480,14 @@ ViewResult: {
         auth_method: str | None = None,
         timeout: int | None = None,
         session: httpx.Client | None = None,
+        _database: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
         Parameters
         ----------
+        partition_id : str
+            The partition&#39;s ID.
         name : str
             The name of the database.
         url : str
@@ -3449,6 +3510,11 @@ ViewResult: {
             The default timeout for requests. Default c.f. `couchdb3.utils.DEFAULT_TIMEOUT`.
         session: httpx.Client
             A specific client to use. Optional - if not provided, a new client will be initialized.
+        _database : Database
+            The owning `Database` instance. Set internally by `Database.get_partition()` to
+            keep the database alive for the lifetime of this partition object. Not part of the
+            public constructor API — pass `None` (default) when constructing a `Partition`
+            directly.
         &#34;&#34;&#34;
         super().__init__(
             name=name,
@@ -3462,7 +3528,21 @@ ViewResult: {
             timeout=timeout,
         )
         self.partition_id = partition_id
-        # self.root = f&#34;{name}/_partition/{partition_id}&#34;
+        self._database = _database
+
+    @property
+    def database(self):
+        &#34;&#34;&#34;
+        The `Database` instance this partition was obtained from, or `None` if the partition
+        was constructed directly (i.e. not via `Database.get_partition()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        Database | None
+        &#34;&#34;&#34;
+        return self._database
 
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
@@ -3898,6 +3978,8 @@ ViewResult: {
 <div class="desc"><p>Abstract Couchdb partition</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
+<dt><strong><code>partition_id</code></strong> :&ensp;<code>str</code></dt>
+<dd>The partition's ID.</dd>
 <dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
 <dd>The name of the database.</dd>
 <dt><strong><code>url</code></strong> :&ensp;<code>str</code></dt>
@@ -3920,12 +4002,49 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <dd>The default timeout for requests. Default c.f. <code><a title="couchdb3.utils.DEFAULT_TIMEOUT" href="../utils.html#couchdb3.utils.DEFAULT_TIMEOUT">DEFAULT_TIMEOUT</a></code>.</dd>
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.Client</code></dt>
 <dd>A specific client to use. Optional - if not provided, a new client will be initialized.</dd>
+<dt><strong><code>_database</code></strong> :&ensp;<code><a title="couchdb3.sync.database.Database" href="#couchdb3.sync.database.Database">Database</a></code></dt>
+<dd>The owning <code><a title="couchdb3.sync.database.Database" href="#couchdb3.sync.database.Database">Database</a></code> instance. Set internally by <code><a title="couchdb3.sync.database.Database.get_partition" href="#couchdb3.sync.database.Database.get_partition">Database.get_partition()</a></code> to
+keep the database alive for the lifetime of this partition object. Not part of the
+public constructor API — pass <code>None</code> (default) when constructing a <code><a title="couchdb3.sync.database.Partition" href="#couchdb3.sync.database.Partition">Partition</a></code>
+directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="couchdb3.sync.database.Database" href="#couchdb3.sync.database.Database">Database</a></li>
 <li><a title="couchdb3.sync.base.Base" href="base.html#couchdb3.sync.base.Base">Base</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.sync.database.Partition.database"><code class="name">prop <span class="ident">database</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def database(self):
+    &#34;&#34;&#34;
+    The `Database` instance this partition was obtained from, or `None` if the partition
+    was constructed directly (i.e. not via `Database.get_partition()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    Database | None
+    &#34;&#34;&#34;
+    return self._database</code></pre>
+</details>
+<div class="desc"><p>The <code><a title="couchdb3.sync.database.Database" href="#couchdb3.sync.database.Database">Database</a></code> instance this partition was obtained from, or <code>None</code> if the partition
+was constructed directly (i.e. not via <code><a title="couchdb3.sync.database.Database.get_partition" href="#couchdb3.sync.database.Database.get_partition">Database.get_partition()</a></code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Database | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.sync.database.Partition.add_partition_to_doc"><code class="name flex">
@@ -4637,6 +4756,7 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.put_design" href="#couchdb3.sync.database.Database.put_design">put_design</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.save_index" href="#couchdb3.sync.database.Database.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.security" href="#couchdb3.sync.database.Database.security">security</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.server" href="#couchdb3.sync.database.Database.server">server</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.update_security" href="#couchdb3.sync.database.Database.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.url" href="base.html#couchdb3.sync.base.Base.url">url</a></code></li>
 </ul>
@@ -4683,6 +4803,7 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.save" href="#couchdb3.sync.database.Database.save">save</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.save_index" href="#couchdb3.sync.database.Database.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.security" href="#couchdb3.sync.database.Database.security">security</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.server" href="#couchdb3.sync.database.Database.server">server</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.update_security" href="#couchdb3.sync.database.Database.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.view" href="#couchdb3.sync.database.Database.view">view</a></code></li>
 </ul>
@@ -4697,6 +4818,7 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Partition.bulk_get" href="#couchdb3.sync.database.Partition.bulk_get">bulk_get</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.copy" href="#couchdb3.sync.database.Partition.copy">copy</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.create" href="#couchdb3.sync.database.Partition.create">create</a></code></li>
+<li><code><a title="couchdb3.sync.database.Partition.database" href="#couchdb3.sync.database.Partition.database">database</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.delete" href="#couchdb3.sync.database.Partition.delete">delete</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.delete_attachment" href="#couchdb3.sync.database.Partition.delete_attachment">delete_attachment</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.find" href="#couchdb3.sync.database.Partition.find">find</a></code></li>

--- a/docs/sync/index.html
+++ b/docs/sync/index.html
@@ -92,6 +92,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         auth_method: str | None = None,
         timeout: int | None = DEFAULT_TIMEOUT,
         session: httpx.Client | None = None,
+        _server: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
@@ -119,6 +120,10 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             The default timeout for requests. Default c.f. `couchdb3.utils.DEFAULT_TIMEOUT`.
         session: httpx.Client
             A specific client to use. Optional - if not provided, a new client will be initialized.
+        _server : Server
+            The owning `Server` instance. Set internally by `Server.get()` to keep the server
+            alive for the lifetime of this database object. Not part of the public constructor
+            API — pass `None` (default) when constructing a `Database` directly.
         &#34;&#34;&#34;
         super().__init__(
             url=url,
@@ -137,6 +142,21 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             )
         self.name = name
         self.root = name
+        self._server = _server
+
+    @property
+    def server(self):
+        &#34;&#34;&#34;
+        The `Server` instance this database was obtained from, or `None` if the database
+        was constructed directly (i.e. not via `Server.get()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        Server | None
+        &#34;&#34;&#34;
+        return self._server
 
     def __getitem__(self, item) -&gt; Document:
         return self.get(docid=item, check=True)
@@ -1338,6 +1358,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,
+            _database=self,
         )</code></pre>
 </details>
 <div class="desc"><p>Abstract Couchdb database</p>
@@ -1365,6 +1386,10 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <dd>The default timeout for requests. Default c.f. <code><a title="couchdb3.utils.DEFAULT_TIMEOUT" href="../utils.html#couchdb3.utils.DEFAULT_TIMEOUT">DEFAULT_TIMEOUT</a></code>.</dd>
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.Client</code></dt>
 <dd>A specific client to use. Optional - if not provided, a new client will be initialized.</dd>
+<dt><strong><code>_server</code></strong> :&ensp;<code><a title="couchdb3.sync.Server" href="#couchdb3.sync.Server">Server</a></code></dt>
+<dd>The owning <code><a title="couchdb3.sync.Server" href="#couchdb3.sync.Server">Server</a></code> instance. Set internally by <code><a title="couchdb3.sync.Server.get" href="#couchdb3.sync.Server.get">Server.get()</a></code> to keep the server
+alive for the lifetime of this database object. Not part of the public constructor
+API — pass <code>None</code> (default) when constructing a <code><a title="couchdb3.sync.Database" href="#couchdb3.sync.Database">Database</a></code> directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -1374,6 +1399,38 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <ul class="hlist">
 <li><a title="couchdb3.sync.database.Partition" href="database.html#couchdb3.sync.database.Partition">Partition</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.sync.Database.server"><code class="name">prop <span class="ident">server</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def server(self):
+    &#34;&#34;&#34;
+    The `Server` instance this database was obtained from, or `None` if the database
+    was constructed directly (i.e. not via `Server.get()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    Server | None
+    &#34;&#34;&#34;
+    return self._server</code></pre>
+</details>
+<div class="desc"><p>The <code><a title="couchdb3.sync.Server" href="#couchdb3.sync.Server">Server</a></code> instance this database was obtained from, or <code>None</code> if the database
+was constructed directly (i.e. not via <code><a title="couchdb3.sync.Server.get" href="#couchdb3.sync.Server.get">Server.get()</a></code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Server | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.sync.Database.all_docs"><code class="name flex">
@@ -2612,6 +2669,7 @@ revisions. Default <code>None</code>.</dd>
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,
+        _database=self,
     )</code></pre>
 </details>
 <div class="desc"><p>Get a given partition.</p>
@@ -3442,11 +3500,14 @@ ViewResult: {
         auth_method: str | None = None,
         timeout: int | None = None,
         session: httpx.Client | None = None,
+        _database: Any = None,
     ) -&gt; None:
         &#34;&#34;&#34;
 
         Parameters
         ----------
+        partition_id : str
+            The partition&#39;s ID.
         name : str
             The name of the database.
         url : str
@@ -3469,6 +3530,11 @@ ViewResult: {
             The default timeout for requests. Default c.f. `couchdb3.utils.DEFAULT_TIMEOUT`.
         session: httpx.Client
             A specific client to use. Optional - if not provided, a new client will be initialized.
+        _database : Database
+            The owning `Database` instance. Set internally by `Database.get_partition()` to
+            keep the database alive for the lifetime of this partition object. Not part of the
+            public constructor API — pass `None` (default) when constructing a `Partition`
+            directly.
         &#34;&#34;&#34;
         super().__init__(
             name=name,
@@ -3482,7 +3548,21 @@ ViewResult: {
             timeout=timeout,
         )
         self.partition_id = partition_id
-        # self.root = f&#34;{name}/_partition/{partition_id}&#34;
+        self._database = _database
+
+    @property
+    def database(self):
+        &#34;&#34;&#34;
+        The `Database` instance this partition was obtained from, or `None` if the partition
+        was constructed directly (i.e. not via `Database.get_partition()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        Database | None
+        &#34;&#34;&#34;
+        return self._database
 
     def __repr__(self) -&gt; str:
         return f&#34;{super().__repr__()}/{self.partition_id}&#34;
@@ -3918,6 +3998,8 @@ ViewResult: {
 <div class="desc"><p>Abstract Couchdb partition</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
+<dt><strong><code>partition_id</code></strong> :&ensp;<code>str</code></dt>
+<dd>The partition's ID.</dd>
 <dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
 <dd>The name of the database.</dd>
 <dt><strong><code>url</code></strong> :&ensp;<code>str</code></dt>
@@ -3940,12 +4022,49 @@ self-signed TLS certificates. Default <code>False</code>.</dd>
 <dd>The default timeout for requests. Default c.f. <code><a title="couchdb3.utils.DEFAULT_TIMEOUT" href="../utils.html#couchdb3.utils.DEFAULT_TIMEOUT">DEFAULT_TIMEOUT</a></code>.</dd>
 <dt><strong><code>session</code></strong> :&ensp;<code>httpx.Client</code></dt>
 <dd>A specific client to use. Optional - if not provided, a new client will be initialized.</dd>
+<dt><strong><code>_database</code></strong> :&ensp;<code><a title="couchdb3.sync.Database" href="#couchdb3.sync.Database">Database</a></code></dt>
+<dd>The owning <code><a title="couchdb3.sync.Database" href="#couchdb3.sync.Database">Database</a></code> instance. Set internally by <code><a title="couchdb3.sync.Database.get_partition" href="#couchdb3.sync.Database.get_partition">Database.get_partition()</a></code> to
+keep the database alive for the lifetime of this partition object. Not part of the
+public constructor API — pass <code>None</code> (default) when constructing a <code><a title="couchdb3.sync.Partition" href="#couchdb3.sync.Partition">Partition</a></code>
+directly.</dd>
 </dl></div>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="couchdb3.sync.database.Database" href="database.html#couchdb3.sync.database.Database">Database</a></li>
 <li><a title="couchdb3.sync.base.Base" href="base.html#couchdb3.sync.base.Base">Base</a></li>
 </ul>
+<h3>Instance variables</h3>
+<dl>
+<dt id="couchdb3.sync.Partition.database"><code class="name">prop <span class="ident">database</span></code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@property
+def database(self):
+    &#34;&#34;&#34;
+    The `Database` instance this partition was obtained from, or `None` if the partition
+    was constructed directly (i.e. not via `Database.get_partition()`).
+
+    Read-only. Setting this attribute raises `AttributeError`.
+
+    Returns
+    -------
+    Database | None
+    &#34;&#34;&#34;
+    return self._database</code></pre>
+</details>
+<div class="desc"><p>The <code><a title="couchdb3.sync.Database" href="#couchdb3.sync.Database">Database</a></code> instance this partition was obtained from, or <code>None</code> if the partition
+was constructed directly (i.e. not via <code><a title="couchdb3.sync.Database.get_partition" href="#couchdb3.sync.Database.get_partition">Database.get_partition()</a></code>).</p>
+<p>Read-only. Setting this attribute raises <code>AttributeError</code>.</p>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>Database | None</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="couchdb3.sync.Partition.add_partition_to_doc"><code class="name flex">
@@ -4657,6 +4776,7 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.put_design" href="database.html#couchdb3.sync.database.Database.put_design">put_design</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.save_index" href="database.html#couchdb3.sync.database.Database.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.security" href="database.html#couchdb3.sync.database.Database.security">security</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.server" href="database.html#couchdb3.sync.database.Database.server">server</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.update_security" href="database.html#couchdb3.sync.database.Database.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.url" href="base.html#couchdb3.sync.base.Base.url">url</a></code></li>
 </ul>
@@ -4958,6 +5078,7 @@ view reflects. Default is <code>False</code>.</dd>
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,
+            _server=self,
         )
         try:
             db._head()
@@ -5786,6 +5907,7 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,
+        _server=self,
     )
     try:
         db._head()
@@ -6590,6 +6712,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.sync.Database.save" href="#couchdb3.sync.Database.save">save</a></code></li>
 <li><code><a title="couchdb3.sync.Database.save_index" href="#couchdb3.sync.Database.save_index">save_index</a></code></li>
 <li><code><a title="couchdb3.sync.Database.security" href="#couchdb3.sync.Database.security">security</a></code></li>
+<li><code><a title="couchdb3.sync.Database.server" href="#couchdb3.sync.Database.server">server</a></code></li>
 <li><code><a title="couchdb3.sync.Database.update_security" href="#couchdb3.sync.Database.update_security">update_security</a></code></li>
 <li><code><a title="couchdb3.sync.Database.view" href="#couchdb3.sync.Database.view">view</a></code></li>
 </ul>
@@ -6604,6 +6727,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.sync.Partition.bulk_get" href="#couchdb3.sync.Partition.bulk_get">bulk_get</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.copy" href="#couchdb3.sync.Partition.copy">copy</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.create" href="#couchdb3.sync.Partition.create">create</a></code></li>
+<li><code><a title="couchdb3.sync.Partition.database" href="#couchdb3.sync.Partition.database">database</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.delete" href="#couchdb3.sync.Partition.delete">delete</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.delete_attachment" href="#couchdb3.sync.Partition.delete_attachment">delete_attachment</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.find" href="#couchdb3.sync.Partition.find">find</a></code></li>

--- a/docs/sync/server.html
+++ b/docs/sync/server.html
@@ -341,6 +341,7 @@ el.replaceWith(d);
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,
+            _server=self,
         )
         try:
             db._head()
@@ -1169,6 +1170,7 @@ used: <code>3</code>, unless overridden in the <code>cluster config</code>).</dd
         disable_ssl_verification=self.disable_ssl_verification,
         auth_method=self.auth_method,
         session=self.session,
+        _server=self,
     )
     try:
         db._head()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "couchdb3"
-version = "3.3.0"
+version = "3.3.1"
 description = "A wrapper around the CouchDB API."
 authors = [{ name = "Nikolai Vlahovic", email = "vlahovic.REDACTED_USERlai@gmail.com" }]
 requires-python = ">= 3.11"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="CouchDB3",
-    version="3.3.0",
+    version="3.3.1",
     author="Nikolai Vlahovic",
     author_email="REDACTED_USERlai@nexup.com",
     description="A wrapper around the CouchDB API.",

--- a/src/couchdb3/aio/async_database.py
+++ b/src/couchdb3/aio/async_database.py
@@ -50,6 +50,7 @@ class AsyncDatabase(AsyncBase):
         auth_method: str | None = None,
         timeout: int | None = DEFAULT_TIMEOUT,
         session: httpx.AsyncClient | None = None,
+        _server: Any = None,
     ) -> None:
         """
 
@@ -79,6 +80,11 @@ class AsyncDatabase(AsyncBase):
         session : httpx.AsyncClient
             A specific async client to use. Optional — if not provided, a new client will be
             initialized.
+        _server : AsyncServer
+            The owning `AsyncServer` instance. Set internally by `AsyncServer.get()` to keep
+            the server alive for the lifetime of this database object. Not part of the public
+            constructor API — pass `None` (default) when constructing an `AsyncDatabase`
+            directly.
         """
         super().__init__(
             url=url,
@@ -97,6 +103,21 @@ class AsyncDatabase(AsyncBase):
             )
         self.name = name
         self.root = name
+        self._server = _server
+
+    @property
+    def server(self):
+        """
+        The `AsyncServer` instance this database was obtained from, or `None` if the database
+        was constructed directly (i.e. not via `AsyncServer.get()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        AsyncServer | None
+        """
+        return self._server
 
     def __repr__(self) -> str:
         """
@@ -1152,6 +1173,7 @@ class AsyncDatabase(AsyncBase):
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,  # shared — child sets _owns_session=False
+            _database=self,
         )
 
 
@@ -1173,6 +1195,7 @@ class AsyncPartition(AsyncDatabase):
         auth_method: str | None = None,
         timeout: int | None = None,
         session: httpx.AsyncClient | None = None,
+        _database: Any = None,
     ) -> None:
         """
 
@@ -1198,6 +1221,11 @@ class AsyncPartition(AsyncDatabase):
             The default timeout for requests. Default `None`.
         session : httpx.AsyncClient
             A specific async client to use. Optional.
+        _database : AsyncDatabase
+            The owning `AsyncDatabase` instance. Set internally by
+            `AsyncDatabase.get_partition()` to keep the database alive for the lifetime of
+            this partition object. Not part of the public constructor API — pass `None`
+            (default) when constructing an `AsyncPartition` directly.
         """
         super().__init__(
             name=name,
@@ -1211,6 +1239,21 @@ class AsyncPartition(AsyncDatabase):
             timeout=timeout,
         )
         self.partition_id = partition_id
+        self._database = _database
+
+    @property
+    def database(self):
+        """
+        The `AsyncDatabase` instance this partition was obtained from, or `None` if the
+        partition was constructed directly (i.e. not via `AsyncDatabase.get_partition()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        AsyncDatabase | None
+        """
+        return self._database
 
     def __repr__(self) -> str:
         return f"{super().__repr__()}/{self.partition_id}"

--- a/src/couchdb3/aio/async_server.py
+++ b/src/couchdb3/aio/async_server.py
@@ -306,6 +306,7 @@ class AsyncServer(AsyncBase):
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,  # shared — child sets _owns_session=False
+            _server=self,
         )
         try:
             await db._head()

--- a/src/couchdb3/sync/database.py
+++ b/src/couchdb3/sync/database.py
@@ -47,6 +47,7 @@ class Database(Base):
         auth_method: str | None = None,
         timeout: int | None = DEFAULT_TIMEOUT,
         session: httpx.Client | None = None,
+        _server: Any = None,
     ) -> None:
         """
 
@@ -74,6 +75,10 @@ class Database(Base):
             The default timeout for requests. Default c.f. `couchdb3.utils.DEFAULT_TIMEOUT`.
         session: httpx.Client
             A specific client to use. Optional - if not provided, a new client will be initialized.
+        _server : Server
+            The owning `Server` instance. Set internally by `Server.get()` to keep the server
+            alive for the lifetime of this database object. Not part of the public constructor
+            API — pass `None` (default) when constructing a `Database` directly.
         """
         super().__init__(
             url=url,
@@ -92,6 +97,21 @@ class Database(Base):
             )
         self.name = name
         self.root = name
+        self._server = _server
+
+    @property
+    def server(self):
+        """
+        The `Server` instance this database was obtained from, or `None` if the database
+        was constructed directly (i.e. not via `Server.get()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        Server | None
+        """
+        return self._server
 
     def __getitem__(self, item) -> Document:
         return self.get(docid=item, check=True)
@@ -1293,6 +1313,7 @@ class Database(Base):
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,
+            _database=self,
         )
 
 
@@ -1314,11 +1335,14 @@ class Partition(Database):
         auth_method: str | None = None,
         timeout: int | None = None,
         session: httpx.Client | None = None,
+        _database: Any = None,
     ) -> None:
         """
 
         Parameters
         ----------
+        partition_id : str
+            The partition's ID.
         name : str
             The name of the database.
         url : str
@@ -1341,6 +1365,11 @@ class Partition(Database):
             The default timeout for requests. Default c.f. `couchdb3.utils.DEFAULT_TIMEOUT`.
         session: httpx.Client
             A specific client to use. Optional - if not provided, a new client will be initialized.
+        _database : Database
+            The owning `Database` instance. Set internally by `Database.get_partition()` to
+            keep the database alive for the lifetime of this partition object. Not part of the
+            public constructor API — pass `None` (default) when constructing a `Partition`
+            directly.
         """
         super().__init__(
             name=name,
@@ -1354,7 +1383,21 @@ class Partition(Database):
             timeout=timeout,
         )
         self.partition_id = partition_id
-        # self.root = f"{name}/_partition/{partition_id}"
+        self._database = _database
+
+    @property
+    def database(self):
+        """
+        The `Database` instance this partition was obtained from, or `None` if the partition
+        was constructed directly (i.e. not via `Database.get_partition()`).
+
+        Read-only. Setting this attribute raises `AttributeError`.
+
+        Returns
+        -------
+        Database | None
+        """
+        return self._database
 
     def __repr__(self) -> str:
         return f"{super().__repr__()}/{self.partition_id}"

--- a/src/couchdb3/sync/server.py
+++ b/src/couchdb3/sync/server.py
@@ -309,6 +309,7 @@ class Server(Base):
             disable_ssl_verification=self.disable_ssl_verification,
             auth_method=self.auth_method,
             session=self.session,
+            _server=self,
         )
         try:
             db._head()

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -331,6 +331,73 @@ class TestAsyncDatabaseChanges(unittest.IsolatedAsyncioTestCase):
             await self.db.changes(doc_ids=["a"], selector={"type": "x"})
 
 
+class TestAsyncDatabaseServerRef(unittest.IsolatedAsyncioTestCase):
+    """Tests for the db.server and partition.database back-references (Option C lifetime fix)."""
+
+    async def asyncSetUp(self):
+        self.server = AsyncServer(url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
+        all_dbs = await self.server.all_dbs()
+        if DB_NAME in all_dbs:
+            self.db = await self.server.get(DB_NAME)
+        else:
+            self.db = await self.server.create(DB_NAME)
+        if DB_NAME_PARTITIONED in all_dbs:
+            self.db_partitioned = await self.server.get(DB_NAME_PARTITIONED)
+        else:
+            self.db_partitioned = await self.server.create(DB_NAME_PARTITIONED, partitioned=True)
+
+    async def asyncTearDown(self):
+        await self.server.aclose()
+
+    async def test_db_server_is_set(self):
+        self.assertIs(self.db.server, self.server)
+
+    async def test_db_server_is_none_when_standalone(self):
+        from couchdb3.aio import AsyncDatabase
+
+        db = AsyncDatabase(
+            name=DB_NAME, url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
+        )
+        self.assertIsNone(db.server)
+        await db.aclose()
+
+    async def test_db_server_is_readonly(self):
+        with self.assertRaises(AttributeError):
+            self.db.server = None
+
+    async def test_partition_database_is_set(self):
+        partition = await self.db_partitioned.get_partition(P_ID)
+        self.assertIs(partition.database, self.db_partitioned)
+
+    async def test_partition_database_is_none_when_standalone(self):
+        from couchdb3.aio import AsyncPartition
+
+        p = AsyncPartition(
+            partition_id=P_ID,
+            name=DB_NAME_PARTITIONED,
+            url=COUCHDB0_URL,
+            user=COUCHDB_USER,
+            password=COUCHDB_PASSWORD,
+        )
+        self.assertIsNone(p.database)
+        await p.aclose()
+
+    async def test_partition_database_is_readonly(self):
+        partition = await self.db_partitioned.get_partition(P_ID)
+        with self.assertRaises(AttributeError):
+            partition.database = None
+
+    async def test_one_liner_does_not_raise(self):
+        # The original bug: temporary AsyncServer GC'd before chained await executes.
+        # db.server holds a strong ref, keeping the AsyncServer (and its httpx.AsyncClient) alive.
+        async with AsyncServer(
+            url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD
+        ) as server:
+            db = await server.get(DB_NAME)
+            result = await db.changes(limit=1)
+            self.assertIn("results", result)
+
+
 @atexit.register
 def rm_test_dbs() -> None:
     """Remove temporary async database test DBs using the sync client."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -447,6 +447,54 @@ class TestDatabase(unittest.TestCase):
             DB.changes(doc_ids=["a"], selector={"type": "x"})
 
 
+class TestDatabaseServerRef(unittest.TestCase):
+    """Tests for the db.server and partition.database back-references (Option C lifetime fix)."""
+
+    def test_db_server_is_set(self):
+        # A Database obtained via Server.get() / Server.__getitem__ carries a ref to the Server
+        db = CLIENT.get(DB_NAME)
+        self.assertIs(db.server, CLIENT)
+
+    def test_db_server_is_none_when_standalone(self):
+        # A Database constructed directly has no server ref
+        db = Database(name=DB_NAME, url=COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)
+        self.assertIsNone(db.server)
+
+    def test_db_server_is_readonly(self):
+        db = CLIENT.get(DB_NAME)
+        with self.assertRaises(AttributeError):
+            db.server = None
+
+    def test_partition_database_is_set(self):
+        partition = DB_PARTITIONED.get_partition(P_ID)
+        self.assertIs(partition.database, DB_PARTITIONED)
+
+    def test_partition_database_is_none_when_standalone(self):
+        from couchdb3.sync import Partition
+
+        p = Partition(
+            partition_id=P_ID,
+            name=DB_NAME_PARTITIONED,
+            url=COUCHDB0_URL,
+            user=COUCHDB_USER,
+            password=COUCHDB_PASSWORD,
+        )
+        self.assertIsNone(p.database)
+
+    def test_partition_database_is_readonly(self):
+        partition = DB_PARTITIONED.get_partition(P_ID)
+        with self.assertRaises(AttributeError):
+            partition.database = None
+
+    def test_one_liner_does_not_raise(self):
+        # The original bug: temporary Server GC'd before chained method executes.
+        # db.server holds a strong ref, keeping the Server (and its httpx.Client) alive.
+        result = Server(COUCHDB0_URL, user=COUCHDB_USER, password=COUCHDB_PASSWORD)[
+            DB_NAME
+        ].changes(limit=1)
+        self.assertIn("results", result)
+
+
 @atexit.register
 def rm_test_db() -> None:
     """

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "couchdb3"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fixes #39.

## Problem

```python
Server(DB_HOST, user=u, password=p)['training-data'].changes(descending=True, limit=10)
# RuntimeError: Cannot send a request, as the client has been closed.
```

The temporary `Server` object had no reference keeping it alive after `__getitem__` returned the `Database`. CPython's reference-counting GC destroyed it immediately, calling `Server.__del__` → `httpx.Client.close()`. The `Database` shared that same client (`session=self.session`), so any subsequent method call on it raised `RuntimeError`.

This affects every chained one-liner pattern, not just `changes()`.

## Fix — Option C (parent reference)

`Database.__init__` gains a `_server=None` keyword parameter. `Server.get()` (and `AsyncServer.get()`) pass `_server=self`. The stored reference prevents the `Server` — and its `httpx.Client` — from being GC'd for the full lifetime of the `Database`. Same pattern one level down: `Partition._database` set by `Database.get_partition()`.

No connection-pool behaviour changes. Cookie auth unaffected.

## New public read-only properties

| Class | Property | Returns |
|---|---|---|
| `Database` | `server` | `Server \| None` |
| `Partition` | `database` | `Database \| None` |
| `AsyncDatabase` | `server` | `AsyncServer \| None` |
| `AsyncPartition` | `database` | `AsyncDatabase \| None` |

`None` when the object is constructed directly (not via `Server.get()` / `Database.get_partition()`). Writing raises `AttributeError` (backed by `_server` / `_database` with no setter).

## Tests

14 new tests in `TestDatabaseServerRef` and `TestAsyncDatabaseServerRef`:
- ref is set correctly when obtained via `Server.get()` / `__getitem__`
- `None` when constructed standalone
- `AttributeError` on write attempt
- original one-liner pattern no longer raises `RuntimeError`

**126 tests pass, 2 skipped** (destructive `setup_cluster` — unchanged).

## Housekeeping
- `ruff check` + `ruff format` — clean
- `make html` — docs regenerated
- `make build` — `couchdb3-3.3.1.tar.gz` + `couchdb3-3.3.1-py3-none-any.whl` built successfully
- Version bumped `3.3.0` → `3.3.1` (patch — bug fix + backward-compatible property additions)