### PR TITLE
v3.4.0 — bug fixes, API additions, expanded test coverage

### DIFF
--- a/.opencode/skills/couchdb3-api-coverage/SKILL.md
+++ b/.opencode/skills/couchdb3-api-coverage/SKILL.md
@@ -31,20 +31,28 @@ description: Use when implementing or tracking missing CouchDB API endpoint cove
 
 ---
 
+## Batch 2 — Database & ergonomic endpoints (v3.4.0)
+
+| Endpoint | Method(s) | Class | Status |
+|---|---|---|---|
+| `DELETE /{db}/_index/{ddoc}/{type}/{name}` | `Database.delete_index()` | Database / AsyncDatabase | ✅ |
+| `GET /{db}/_design_docs` | `Database.design_docs()` | Database / AsyncDatabase | ✅ |
+| `HEAD /{db}` (existence) | `AsyncServer.has_db()` | AsyncServer | ✅ |
+
+Bug fixes in v3.4.0: `Database.put_design()` no longer drops `options` when
+`partitioned=True`; `Server.replicate()` now posts to the one-shot `/_replicate`
+endpoint (dropping the invalid `_id` field and mapping `filter_func` → `filter`).
+
+---
+
 ## Still pending (from TODO.md)
 
 | Endpoint | Notes |
 |---|---|
-| `DELETE /{db}/_index/{ddoc}/json/{name}` | Delete a Mango index |
-| `GET /{db}/_design_docs` | List design documents |
 | `GET /{db}/_local_docs` / `GET\|PUT\|DELETE /{db}/_local/{docid}` | Local documents |
-| `GET /_membership` | ✅ done in Batch 1 |
-| `POST /_cluster_setup` / `GET /_cluster_setup` | ✅ done in Batch 1 |
-| `GET /_node/{node}/_config`, `_stats`, `_system` | ✅ done in Batch 1 |
 | `GET\|PUT /{db}/_revs_limit` | Revision limit management |
 | `POST /{db}/_missing_revs` / `POST /{db}/_revs_diff` | Replication helpers |
 | `POST /{db}/_view_cleanup` | View index cleanup |
-| `__contains__` on `AsyncServer` | Ergonomic gap — Python disallows async `__contains__` but a helper like `await client.has_db(name)` could fill the gap |
 | `GET /{db}/_changes` with `feed=continuous\|eventsource` | Streaming feeds — deferred; requires iterator/stream response handling |
 
 ---
@@ -147,3 +155,19 @@ Annotate as `dict | str` to cover all three cases.
 | `tests/test_async_server.py` | Same tests, async |
 | `TODO.md` | Struck through completed items |
 | `pyproject.toml` / `setup.py` | Version bumped to `3.3.0` |
+
+## Files modified in Batch 2
+
+| File | Change |
+|---|---|
+| `src/couchdb3/sync/database.py` | Fixed `put_design` options bug; added `delete_index`, `design_docs`; removed orphaned `:return:` stub |
+| `src/couchdb3/aio/async_database.py` | Same, async |
+| `src/couchdb3/sync/server.py` | Fixed `replicate` → `/_replicate`; fixed `__repr__` docstring |
+| `src/couchdb3/aio/async_server.py` | Fixed `replicate` → `/_replicate`; added `has_db` |
+| `tests/test_database.py` | `test_delete_index`, `test_design_docs`, `test_compact_with_ddoc`, `test_purge` |
+| `tests/test_async_database.py` | Same tests, async |
+| `tests/test_server.py` | `test_replicate` now asserts `session_id`; `test_cookie_auth_token_renewal` |
+| `tests/test_async_server.py` | `test_has_db`; `test_replicate` now asserts `session_id` |
+| `tests/test_partitioned_database.py` | `TestPartition` — full sync `Partition` method coverage |
+| `TODO.md` | Struck through completed items |
+| `pyproject.toml` / `setup.py` | Version bumped to `3.4.0` |

--- a/.opencode/skills/couchdb3-version-bump/SKILL.md
+++ b/.opencode/skills/couchdb3-version-bump/SKILL.md
@@ -55,3 +55,4 @@ description: Use when bumping the couchdb3 version. Lists every file to update, 
 | `3.2.1` | #36 | Linting/style fixes, ruff config, dependency cleanup |
 | `3.3.0` | #37 | `Database.changes()`, `Server.membership()`, `cluster_setup()`, `setup_cluster()`, `node_config()`, `set_node_config()`, `delete_node_config()`, `reload_node_config()`, `node_stats()`, `node_system()` — all sync + async |
 | `3.3.1` | #38 | Fix `RuntimeError` on chained `Server().__getitem__().method()` (session lifetime bug, issue #39); adds read-only `Database.server`, `Partition.database`, `AsyncDatabase.server`, `AsyncPartition.database` back-reference properties |
+| `3.4.0` | #40 | `Database.delete_index()`, `Database.design_docs()`, `AsyncServer.has_db()` (all sync + async); fix `put_design` options bug and `Server.replicate` endpoint; broader test coverage |

--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ await client.aclose()
 ```
 
 Note: `AsyncServer` does not implement `__getitem__` — Python does not allow `__getitem__` to
-be a coroutine. Use `await client.get(name)` instead of `client[name]`.
+be a coroutine. Use `await client.get(name)` instead of `client[name]`. Similarly, for the
+sync `name in server` existence check, use `await client.has_db(name)`.
 
 ### Getting or creating a database
 ```python

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ await client.aclose()
 
 Note: `AsyncServer` does not implement `__getitem__` — Python does not allow `__getitem__` to
 be a coroutine. Use `await client.get(name)` instead of `client[name]`. Similarly, for the
-sync `name in server` existence check, use `await client.has_db(name)`.
+async equivalent of the sync `name in server` check, use `await client.has_db(name)`.
 
 ### Getting or creating a database
 ```python

--- a/TODO.md
+++ b/TODO.md
@@ -5,31 +5,31 @@
 
 ## Misc
 - <s>Abstract away partition path insertion</s>
-- Fix `put_design` bug: `options = (options or {}).update(...)` always sets `options = None` (both sync and async)
-- Fix `Server.__repr__` docstring — currently copy-pasted from `__del__`, says "Close the session on delete"
-- Fix `Server.replicate` — posts to `_replicator` DB instead of `/_replicate` endpoint (persistent vs. one-shot replication)
-- Remove dead code: commented-out `self.root` line in `Partition.__init__`
-- Remove orphaned `:return:` stub at end of `Database.save` docstring
+- <s>Fix `put_design` bug: `options = (options or {}).update(...)` always sets `options = None` (both sync and async)</s> — fixed in v3.4.0
+- <s>Fix `Server.__repr__` docstring — currently copy-pasted from `__del__`, says "Close the session on delete"</s> — fixed in v3.4.0
+- <s>Fix `Server.replicate` — posts to `_replicator` DB instead of `/_replicate` endpoint (persistent vs. one-shot replication)</s> — fixed in v3.4.0
+- <s>Remove dead code: commented-out `self.root` line in `Partition.__init__`</s> — no dead code present
+- <s>Remove orphaned `:return:` stub at end of `Database.save` docstring</s> — fixed in v3.4.0
 
 ## Test
 - <s>Add partitioned methods tests</s> — `test_partitioned_database.py` has 2 tests (`test_create`, `test_put_design`); `Partition` class methods are untested in sync (async covered via `TestAsyncPartition`)
-- Add sync `Partition` method tests: `get`, `save`, `rev`, `delete`, `all_docs`, `find`, `view`, `info`, `bulk_docs`, `bulk_get`, `__contains__`
-- Add test for cookie auth token renewal path (`_is_auth_token_expired` + `_renew_auth_token`)
-- Add test for `Database.purge`
-- Add test for `Database.compact(ddoc=...)` (only no-arg path is tested)
+- <s>Add sync `Partition` method tests: `get`, `save`, `rev`, `delete`, `all_docs`, `find`, `view`, `info`, `bulk_docs`, `bulk_get`, `__contains__`</s> — added in v3.4.0
+- <s>Add test for cookie auth token renewal path (`_is_auth_token_expired` + `_renew_auth_token`)</s> — added in v3.4.0
+- <s>Add test for `Database.purge`</s> — added in v3.4.0
+- <s>Add test for `Database.compact(ddoc=...)` (only no-arg path is tested)</s> — added in v3.4.0
 
 ## Missing API coverage
 - <s>`GET /{db}/_changes` — change feed (polling / longpoll / continuous)</s> — `normal` and `longpoll` implemented in v3.3.0; `continuous`/`eventsource` streaming deferred
 - <s>`GET /_membership` — cluster node membership</s> — implemented in v3.3.0
 - <s>`POST /_cluster_setup` / `GET /_cluster_setup` — cluster setup API</s> — implemented in v3.3.0 (`cluster_setup` + `setup_cluster`)
 - <s>`GET /_node/{node}/_config`, `_stats`, `_system` — node-level APIs</s> — implemented in v3.3.0 (`node_config`, `set_node_config`, `delete_node_config`, `reload_node_config`, `node_stats`, `node_system`)
-- `DELETE /{db}/_index/{ddoc}/json/{name}` — delete a Mango index
-- `GET /{db}/_design_docs` — list design documents
+- <s>`DELETE /{db}/_index/{ddoc}/json/{name}` — delete a Mango index</s> — implemented in v3.4.0 (`delete_index`)
+- <s>`GET /{db}/_design_docs` — list design documents</s> — implemented in v3.4.0 (`design_docs`)
+- <s>`__contains__` on `AsyncServer` (sync `Server` supports `if db in server`; async does not)</s> — implemented in v3.4.0 as `AsyncServer.has_db()`
 - `GET /{db}/_local_docs` / `GET|PUT|DELETE /{db}/_local/{docid}` — local documents
 - `GET|PUT /{db}/_revs_limit` — revision limit management
 - `POST /{db}/_missing_revs` / `POST /{db}/_revs_diff` — replication helpers
 - `POST /{db}/_view_cleanup` — view index cleanup
-- `__contains__` on `AsyncServer` (sync `Server` supports `if db in server`; async does not)
 - `GET /{db}/_changes` with `feed=continuous|eventsource` — streaming feeds (deferred)
   - **sync:** implement `Database.changes_stream()` as a generator using `httpx.Client.stream()`, yielding parsed JSON objects line-by-line from the NDJSON response; caller controls iteration and closure via a `with` block or explicit `.close()`
   - **async:** implement `AsyncDatabase.changes_stream()` as an async generator using `httpx.AsyncClient.stream()`, yielding the same parsed objects; caller drives with `async for` and the underlying connection is released on `aclose()` or generator exhaustion

--- a/docs/aio/async_base.html
+++ b/docs/aio/async_base.html
@@ -207,10 +207,10 @@ el.replaceWith(d);
         bool : `True` if the auth token is expired or absent.
         &#34;&#34;&#34;
         try:
-            return (
-                next(_.expires for _ in self.session.cookies.jar if _.name == &#34;AuthSession&#34;)
-                &lt;= datetime.now(UTC).timestamp()
-            )
+            expires = next(_.expires for _ in self.session.cookies.jar if _.name == &#34;AuthSession&#34;)
+            if expires is None:
+                return False
+            return expires &lt;= datetime.now(UTC).timestamp()
         except StopIteration:
             return True
 

--- a/docs/aio/async_database.html
+++ b/docs/aio/async_database.html
@@ -185,6 +185,72 @@ el.replaceWith(d);
             **kwargs,
         )
 
+    async def design_docs(
+        self,
+        *,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        endkey: str | None = None,
+        include_docs: bool | None = None,
+        keys: Iterable[str] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+        startkey: str | None = None,
+        update_seq: bool | None = None,
+    ) -&gt; ViewResult:
+        &#34;&#34;&#34;
+        Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+        This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+        Parameters
+        ----------
+        conflicts : bool
+            Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+        descending : bool
+            Return the documents in descending order by key. Default is `None`.
+        endkey : str
+            Stop returning records when the specified key is reached. Default is `None`.
+        include_docs : bool
+            Include the associated document with each row. Default is `None`.
+        keys : Iterable[str]
+            Return only documents where the key matches one of the keys specified in the argument.
+            Default is `None`.
+        limit : int
+            Limit the number of the returned documents. Default is `None`.
+        skip : int
+            Skip this number of records before starting to return the results. Default is `None`.
+        startkey : str
+            Return records starting with the specified key. Default is `None`.
+        update_seq : bool
+            Whether to include an `update_seq` value indicating the sequence id of the database.
+            Default is `None`.
+
+        Returns
+        -------
+        ViewResult
+        &#34;&#34;&#34;
+        return ViewResult(
+            **(
+                await self._get(
+                    resource=&#34;_design_docs&#34;,
+                    query_kwargs=rm_nones_from_dict(
+                        {
+                            &#34;conflicts&#34;: conflicts,
+                            &#34;descending&#34;: descending,
+                            &#34;endkey&#34;: endkey,
+                            &#34;include_docs&#34;: include_docs,
+                            &#34;keys&#34;: keys,
+                            &#34;limit&#34;: limit,
+                            &#34;skip&#34;: skip,
+                            &#34;startkey&#34;: startkey,
+                            &#34;update_seq&#34;: update_seq,
+                        }
+                    ),
+                )
+            ).json()
+        )
+
     async def bulk_docs(
         self,
         docs: list[dict | Document],
@@ -782,7 +848,7 @@ el.replaceWith(d);
         tuple[str, bool, str] : (id, ok, rev)
         &#34;&#34;&#34;
         if partitioned:
-            options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+            options = {**(options or {}), &#34;partitioned&#34;: partitioned}
         return await self.save(
             doc=rm_nones_from_dict(
                 {
@@ -882,6 +948,28 @@ el.replaceWith(d);
             )
         ).json()
         return data[&#34;result&#34;], data[&#34;id&#34;], data[&#34;name&#34;]
+
+    async def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Delete an index from a database. For more info, please refer to
+        [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+        Parameters
+        ----------
+        ddoc : str
+            Name of the design document the index belongs to. A `_design/` prefix is stripped
+            automatically.
+        name : str
+            Name of the index.
+        index_type : str
+            Can be `json` or `text`. Defaults to `json`.
+
+        Returns
+        -------
+        bool : `True` upon successful deletion.
+        &#34;&#34;&#34;
+        ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+        return (await self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;)).json().get(&#34;ok&#34;)
 
     async def security(self) -&gt; SecurityDocument:
         &#34;&#34;&#34;
@@ -1885,6 +1973,156 @@ sharded databases).</dd>
 <h2 id="returns">Returns</h2>
 <p>bool : <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.aio.async_database.AsyncDatabase.delete_index"><code class="name flex">
+<span>async def <span class="ident">delete_index</span></span>(<span>self, ddoc: str, name: str, index_type: str = 'json') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Delete an index from a database. For more info, please refer to
+    [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+    Parameters
+    ----------
+    ddoc : str
+        Name of the design document the index belongs to. A `_design/` prefix is stripped
+        automatically.
+    name : str
+        Name of the index.
+    index_type : str
+        Can be `json` or `text`. Defaults to `json`.
+
+    Returns
+    -------
+    bool : `True` upon successful deletion.
+    &#34;&#34;&#34;
+    ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+    return (await self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;)).json().get(&#34;ok&#34;)</code></pre>
+</details>
+<div class="desc"><p>Delete an index from a database. For more info, please refer to
+<a href="https://docs.couchdb.org/en/main/api/database/find.html#db-index">the official documentation</a>.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ddoc</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the design document the index belongs to. A <code>_design/</code> prefix is stripped
+automatically.</dd>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the index.</dd>
+<dt><strong><code>index_type</code></strong> :&ensp;<code>str</code></dt>
+<dd>Can be <code>json</code> or <code>text</code>. Defaults to <code>json</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> upon successful deletion.</p></div>
+</dd>
+<dt id="couchdb3.aio.async_database.AsyncDatabase.design_docs"><code class="name flex">
+<span>async def <span class="ident">design_docs</span></span>(<span>self,<br>*,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>endkey: str | None = None,<br>include_docs: bool | None = None,<br>keys: Iterable[str] | None = None,<br>limit: int | None = None,<br>skip: int | None = None,<br>startkey: str | None = None,<br>update_seq: bool | None = None) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def design_docs(
+    self,
+    *,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    endkey: str | None = None,
+    include_docs: bool | None = None,
+    keys: Iterable[str] | None = None,
+    limit: int | None = None,
+    skip: int | None = None,
+    startkey: str | None = None,
+    update_seq: bool | None = None,
+) -&gt; ViewResult:
+    &#34;&#34;&#34;
+    Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+    This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+    Parameters
+    ----------
+    conflicts : bool
+        Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+    descending : bool
+        Return the documents in descending order by key. Default is `None`.
+    endkey : str
+        Stop returning records when the specified key is reached. Default is `None`.
+    include_docs : bool
+        Include the associated document with each row. Default is `None`.
+    keys : Iterable[str]
+        Return only documents where the key matches one of the keys specified in the argument.
+        Default is `None`.
+    limit : int
+        Limit the number of the returned documents. Default is `None`.
+    skip : int
+        Skip this number of records before starting to return the results. Default is `None`.
+    startkey : str
+        Return records starting with the specified key. Default is `None`.
+    update_seq : bool
+        Whether to include an `update_seq` value indicating the sequence id of the database.
+        Default is `None`.
+
+    Returns
+    -------
+    ViewResult
+    &#34;&#34;&#34;
+    return ViewResult(
+        **(
+            await self._get(
+                resource=&#34;_design_docs&#34;,
+                query_kwargs=rm_nones_from_dict(
+                    {
+                        &#34;conflicts&#34;: conflicts,
+                        &#34;descending&#34;: descending,
+                        &#34;endkey&#34;: endkey,
+                        &#34;include_docs&#34;: include_docs,
+                        &#34;keys&#34;: keys,
+                        &#34;limit&#34;: limit,
+                        &#34;skip&#34;: skip,
+                        &#34;startkey&#34;: startkey,
+                        &#34;update_seq&#34;: update_seq,
+                    }
+                ),
+            )
+        ).json()
+    )</code></pre>
+</details>
+<div class="desc"><p>Executes the built-in <code>_design_docs</code> view, returning all the design documents in the database.</p>
+<p>This is a shorthand for <code>_all_docs</code> filtered to the <code>_design/</code> key range.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Ignored if <code>include_docs</code> isn't <code>True</code>. Default is <code>None</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return the documents in descending order by key. Default is <code>None</code>.</dd>
+<dt><strong><code>endkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Stop returning records when the specified key is reached. Default is <code>None</code>.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each row. Default is <code>None</code>.</dd>
+<dt><strong><code>keys</code></strong> :&ensp;<code>Iterable[str]</code></dt>
+<dd>Return only documents where the key matches one of the keys specified in the argument.
+Default is <code>None</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Limit the number of the returned documents. Default is <code>None</code>.</dd>
+<dt><strong><code>skip</code></strong> :&ensp;<code>int</code></dt>
+<dd>Skip this number of records before starting to return the results. Default is <code>None</code>.</dd>
+<dt><strong><code>startkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return records starting with the specified key. Default is <code>None</code>.</dd>
+<dt><strong><code>update_seq</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Whether to include an <code>update_seq</code> value indicating the sequence id of the database.
+Default is <code>None</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>ViewResult</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
 <dt id="couchdb3.aio.async_database.AsyncDatabase.explain"><code class="name flex">
 <span>async def <span class="ident">explain</span></span>(<span>self,<br>selector: dict,<br>limit: int = 25,<br>skip: int = 0,<br>sort: list[dict] | None = None,<br>fields: list[str] | None = None,<br>use_index: str | list[str] | None = None,<br>conflicts: bool = False,<br>r: int = 1,<br>bookmark: str | None = None,<br>update: bool = True,<br>stable: bool | None = None,<br>execution_stats: bool = False) ‑> dict</span>
 </code></dt>
@@ -2592,7 +2830,7 @@ Default <code>None</code>.</dd>
     tuple[str, bool, str] : (id, ok, rev)
     &#34;&#34;&#34;
     if partitioned:
-        options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+        options = {**(options or {}), &#34;partitioned&#34;: partitioned}
     return await self.save(
         doc=rm_nones_from_dict(
             {
@@ -3268,7 +3506,7 @@ Default <code>None</code>.</dd>
     async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
         &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
         return await super().bulk_get(
-            docs=[self.add_partition_to_doc(doc) for doc in docs],
+            docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
             revs=revs,
         )
 
@@ -3404,7 +3642,7 @@ Default <code>None</code>.</dd>
 
     def add_partition_to_str(self, string: str) -&gt; str:
         &#34;&#34;&#34;Append the instance&#39;s partition ID to a string if not already present.&#34;&#34;&#34;
-        if string.startswith(self.partition_id):
+        if string.startswith(f&#34;{self.partition_id}:&#34;):
             return string
         return f&#34;{self.partition_id}:{string}&#34;
 
@@ -3414,6 +3652,14 @@ Default <code>None</code>.</dd>
         if docid is None:
             return doc
         doc[&#34;_id&#34;] = self.add_partition_to_str(docid)
+        return doc
+
+    def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+        &#34;&#34;&#34;Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).&#34;&#34;&#34;
+        key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+        if key is None:
+            return doc
+        doc[key] = self.add_partition_to_str(doc[key])
         return doc</code></pre>
 </details>
 <div class="desc"><p>Async CouchDB partition client. Mirrors <code>Partition</code> with <code>async def</code> methods throughout.</p>
@@ -3484,6 +3730,24 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.as
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="couchdb3.aio.async_database.AsyncPartition.add_partition_to_bulk_get_doc"><code class="name flex">
+<span>def <span class="ident">add_partition_to_bulk_get_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+    &#34;&#34;&#34;Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).&#34;&#34;&#34;
+    key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+    if key is None:
+        return doc
+    doc[key] = self.add_partition_to_str(doc[key])
+    return doc</code></pre>
+</details>
+<div class="desc"><p>Append the instance's partition ID to a <code>bulk_get</code> document's <code>id</code> (or <code>_id</code>).</p></div>
+</dd>
 <dt id="couchdb3.aio.async_database.AsyncPartition.add_partition_to_doc"><code class="name flex">
 <span>def <span class="ident">add_partition_to_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
 </code></dt>
@@ -3512,7 +3776,7 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.as
 </summary>
 <pre><code class="python">def add_partition_to_str(self, string: str) -&gt; str:
     &#34;&#34;&#34;Append the instance&#39;s partition ID to a string if not already present.&#34;&#34;&#34;
-    if string.startswith(self.partition_id):
+    if string.startswith(f&#34;{self.partition_id}:&#34;):
         return string
     return f&#34;{self.partition_id}:{string}&#34;</code></pre>
 </details>
@@ -3585,7 +3849,7 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.as
 <pre><code class="python">async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
     &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
     return await super().bulk_get(
-        docs=[self.add_partition_to_doc(doc) for doc in docs],
+        docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
         revs=revs,
     )</code></pre>
 </details>
@@ -3956,6 +4220,8 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.as
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.changes" href="#couchdb3.aio.async_database.AsyncDatabase.changes">changes</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.check" href="async_base.html#couchdb3.aio.async_base.AsyncBase.check">check</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.compact" href="#couchdb3.aio.async_database.AsyncDatabase.compact">compact</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.delete_index" href="#couchdb3.aio.async_database.AsyncDatabase.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.design_docs" href="#couchdb3.aio.async_database.AsyncDatabase.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.explain" href="#couchdb3.aio.async_database.AsyncDatabase.explain">explain</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.get_design" href="#couchdb3.aio.async_database.AsyncDatabase.get_design">get_design</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.get_partition" href="#couchdb3.aio.async_database.AsyncDatabase.get_partition">get_partition</a></code></li>
@@ -3998,6 +4264,8 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.as
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.create" href="#couchdb3.aio.async_database.AsyncDatabase.create">create</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.delete" href="#couchdb3.aio.async_database.AsyncDatabase.delete">delete</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.delete_attachment" href="#couchdb3.aio.async_database.AsyncDatabase.delete_attachment">delete_attachment</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.delete_index" href="#couchdb3.aio.async_database.AsyncDatabase.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.design_docs" href="#couchdb3.aio.async_database.AsyncDatabase.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.explain" href="#couchdb3.aio.async_database.AsyncDatabase.explain">explain</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.find" href="#couchdb3.aio.async_database.AsyncDatabase.find">find</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.get" href="#couchdb3.aio.async_database.AsyncDatabase.get">get</a></code></li>
@@ -4019,6 +4287,7 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.as
 <li>
 <h4><code><a title="couchdb3.aio.async_database.AsyncPartition" href="#couchdb3.aio.async_database.AsyncPartition">AsyncPartition</a></code></h4>
 <ul class="">
+<li><code><a title="couchdb3.aio.async_database.AsyncPartition.add_partition_to_bulk_get_doc" href="#couchdb3.aio.async_database.AsyncPartition.add_partition_to_bulk_get_doc">add_partition_to_bulk_get_doc</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.add_partition_to_doc" href="#couchdb3.aio.async_database.AsyncPartition.add_partition_to_doc">add_partition_to_doc</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.add_partition_to_str" href="#couchdb3.aio.async_database.AsyncPartition.add_partition_to_str">add_partition_to_str</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncPartition.all_docs" href="#couchdb3.aio.async_database.AsyncPartition.all_docs">all_docs</a></code></li>

--- a/docs/aio/async_server.html
+++ b/docs/aio/async_server.html
@@ -366,6 +366,29 @@ el.replaceWith(d);
         await self._delete(resource=resource)
         return True
 
+    async def has_db(self, name: str) -&gt; bool:
+        &#34;&#34;&#34;
+        Check if the server contains a database with the given name.
+
+        Note:
+        The async client cannot support the `name in server` syntax (Python does not allow
+        `__contains__` to be a coroutine). Use `await client.has_db(name)` instead.
+
+        Parameters
+        ----------
+        name : str
+            The database&#39;s name.
+
+        Returns
+        -------
+        bool : `True` if the database exists, otherwise `False`.
+        &#34;&#34;&#34;
+        try:
+            await self._head(resource=name)
+            return True
+        except CouchDBError:
+            return False
+
     async def replicate(
         self,
         source: dict | str,
@@ -392,7 +415,8 @@ el.replaceWith(d);
         target : dict | str
             Fully qualified target database URL or an object with URL and headers.
         replication_id : str
-            The ID of the replication document.
+            Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+            a replication document ID).
         cancel : bool
             Cancels the replication.
         continuous : bool
@@ -426,10 +450,9 @@ el.replaceWith(d);
             )
         return (
             await self._post(
-                resource=&#34;_replicator&#34;,
+                resource=&#34;_replicate&#34;,
                 body=rm_nones_from_dict(
                     {
-                        &#34;_id&#34;: replication_id,
                         &#34;source&#34;: source,
                         &#34;target&#34;: target,
                         &#34;cancel&#34;: cancel,
@@ -437,7 +460,7 @@ el.replaceWith(d);
                         &#34;create_target&#34;: create_target,
                         &#34;create_target_params&#34;: create_target_params,
                         &#34;doc_ids&#34;: doc_ids,
-                        &#34;filter_func&#34;: filter_func,
+                        &#34;filter&#34;: filter_func,
                         &#34;selector&#34;: selector,
                         &#34;source_proxy&#34;: source_proxy,
                         &#34;target_proxy&#34;: target_proxy,
@@ -1183,6 +1206,49 @@ Defaults to <code>["_users", "_replicator"]</code>.</dd>
 <dd>&nbsp;</dd>
 </dl></div>
 </dd>
+<dt id="couchdb3.aio.async_server.AsyncServer.has_db"><code class="name flex">
+<span>async def <span class="ident">has_db</span></span>(<span>self, name: str) ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def has_db(self, name: str) -&gt; bool:
+    &#34;&#34;&#34;
+    Check if the server contains a database with the given name.
+
+    Note:
+    The async client cannot support the `name in server` syntax (Python does not allow
+    `__contains__` to be a coroutine). Use `await client.has_db(name)` instead.
+
+    Parameters
+    ----------
+    name : str
+        The database&#39;s name.
+
+    Returns
+    -------
+    bool : `True` if the database exists, otherwise `False`.
+    &#34;&#34;&#34;
+    try:
+        await self._head(resource=name)
+        return True
+    except CouchDBError:
+        return False</code></pre>
+</details>
+<div class="desc"><p>Check if the server contains a database with the given name.</p>
+<p>Note:
+The async client cannot support the <code>name in server</code> syntax (Python does not allow
+<code>__contains__</code> to be a coroutine). Use <code>await client.has_db(name)</code> instead.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The database's name.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> if the database exists, otherwise <code>False</code>.</p></div>
+</dd>
 <dt id="couchdb3.aio.async_server.AsyncServer.membership"><code class="name flex">
 <span>async def <span class="ident">membership</span></span>(<span>self) ‑> dict</span>
 </code></dt>
@@ -1424,7 +1490,8 @@ that have not been written to disk.</p>
     target : dict | str
         Fully qualified target database URL or an object with URL and headers.
     replication_id : str
-        The ID of the replication document.
+        Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+        a replication document ID).
     cancel : bool
         Cancels the replication.
     continuous : bool
@@ -1458,10 +1525,9 @@ that have not been written to disk.</p>
         )
     return (
         await self._post(
-            resource=&#34;_replicator&#34;,
+            resource=&#34;_replicate&#34;,
             body=rm_nones_from_dict(
                 {
-                    &#34;_id&#34;: replication_id,
                     &#34;source&#34;: source,
                     &#34;target&#34;: target,
                     &#34;cancel&#34;: cancel,
@@ -1469,7 +1535,7 @@ that have not been written to disk.</p>
                     &#34;create_target&#34;: create_target,
                     &#34;create_target_params&#34;: create_target_params,
                     &#34;doc_ids&#34;: doc_ids,
-                    &#34;filter_func&#34;: filter_func,
+                    &#34;filter&#34;: filter_func,
                     &#34;selector&#34;: selector,
                     &#34;source_proxy&#34;: source_proxy,
                     &#34;target_proxy&#34;: target_proxy,
@@ -1487,7 +1553,8 @@ that have not been written to disk.</p>
 <dt><strong><code>target</code></strong> :&ensp;<code>dict | str</code></dt>
 <dd>Fully qualified target database URL or an object with URL and headers.</dd>
 <dt><strong><code>replication_id</code></strong> :&ensp;<code>str</code></dt>
-<dd>The ID of the replication document.</dd>
+<dd>Deprecated. Ignored for one-shot replication (the <code>_replicate</code> endpoint does not accept
+a replication document ID).</dd>
 <dt><strong><code>cancel</code></strong> :&ensp;<code>bool</code></dt>
 <dd>Cancels the replication.</dd>
 <dt><strong><code>continuous</code></strong> :&ensp;<code>bool</code></dt>
@@ -1881,6 +1948,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.delete" href="#couchdb3.aio.async_server.AsyncServer.delete">delete</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.delete_node_config" href="#couchdb3.aio.async_server.AsyncServer.delete_node_config">delete_node_config</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.get" href="#couchdb3.aio.async_server.AsyncServer.get">get</a></code></li>
+<li><code><a title="couchdb3.aio.async_server.AsyncServer.has_db" href="#couchdb3.aio.async_server.AsyncServer.has_db">has_db</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.membership" href="#couchdb3.aio.async_server.AsyncServer.membership">membership</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.node_config" href="#couchdb3.aio.async_server.AsyncServer.node_config">node_config</a></code></li>
 <li><code><a title="couchdb3.aio.async_server.AsyncServer.node_stats" href="#couchdb3.aio.async_server.AsyncServer.node_stats">node_stats</a></code></li>

--- a/docs/aio/index.html
+++ b/docs/aio/index.html
@@ -205,6 +205,72 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             **kwargs,
         )
 
+    async def design_docs(
+        self,
+        *,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        endkey: str | None = None,
+        include_docs: bool | None = None,
+        keys: Iterable[str] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+        startkey: str | None = None,
+        update_seq: bool | None = None,
+    ) -&gt; ViewResult:
+        &#34;&#34;&#34;
+        Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+        This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+        Parameters
+        ----------
+        conflicts : bool
+            Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+        descending : bool
+            Return the documents in descending order by key. Default is `None`.
+        endkey : str
+            Stop returning records when the specified key is reached. Default is `None`.
+        include_docs : bool
+            Include the associated document with each row. Default is `None`.
+        keys : Iterable[str]
+            Return only documents where the key matches one of the keys specified in the argument.
+            Default is `None`.
+        limit : int
+            Limit the number of the returned documents. Default is `None`.
+        skip : int
+            Skip this number of records before starting to return the results. Default is `None`.
+        startkey : str
+            Return records starting with the specified key. Default is `None`.
+        update_seq : bool
+            Whether to include an `update_seq` value indicating the sequence id of the database.
+            Default is `None`.
+
+        Returns
+        -------
+        ViewResult
+        &#34;&#34;&#34;
+        return ViewResult(
+            **(
+                await self._get(
+                    resource=&#34;_design_docs&#34;,
+                    query_kwargs=rm_nones_from_dict(
+                        {
+                            &#34;conflicts&#34;: conflicts,
+                            &#34;descending&#34;: descending,
+                            &#34;endkey&#34;: endkey,
+                            &#34;include_docs&#34;: include_docs,
+                            &#34;keys&#34;: keys,
+                            &#34;limit&#34;: limit,
+                            &#34;skip&#34;: skip,
+                            &#34;startkey&#34;: startkey,
+                            &#34;update_seq&#34;: update_seq,
+                        }
+                    ),
+                )
+            ).json()
+        )
+
     async def bulk_docs(
         self,
         docs: list[dict | Document],
@@ -802,7 +868,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         tuple[str, bool, str] : (id, ok, rev)
         &#34;&#34;&#34;
         if partitioned:
-            options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+            options = {**(options or {}), &#34;partitioned&#34;: partitioned}
         return await self.save(
             doc=rm_nones_from_dict(
                 {
@@ -902,6 +968,28 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             )
         ).json()
         return data[&#34;result&#34;], data[&#34;id&#34;], data[&#34;name&#34;]
+
+    async def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Delete an index from a database. For more info, please refer to
+        [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+        Parameters
+        ----------
+        ddoc : str
+            Name of the design document the index belongs to. A `_design/` prefix is stripped
+            automatically.
+        name : str
+            Name of the index.
+        index_type : str
+            Can be `json` or `text`. Defaults to `json`.
+
+        Returns
+        -------
+        bool : `True` upon successful deletion.
+        &#34;&#34;&#34;
+        ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+        return (await self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;)).json().get(&#34;ok&#34;)
 
     async def security(self) -&gt; SecurityDocument:
         &#34;&#34;&#34;
@@ -1905,6 +1993,156 @@ sharded databases).</dd>
 <h2 id="returns">Returns</h2>
 <p>bool : <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.aio.AsyncDatabase.delete_index"><code class="name flex">
+<span>async def <span class="ident">delete_index</span></span>(<span>self, ddoc: str, name: str, index_type: str = 'json') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Delete an index from a database. For more info, please refer to
+    [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+    Parameters
+    ----------
+    ddoc : str
+        Name of the design document the index belongs to. A `_design/` prefix is stripped
+        automatically.
+    name : str
+        Name of the index.
+    index_type : str
+        Can be `json` or `text`. Defaults to `json`.
+
+    Returns
+    -------
+    bool : `True` upon successful deletion.
+    &#34;&#34;&#34;
+    ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+    return (await self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;)).json().get(&#34;ok&#34;)</code></pre>
+</details>
+<div class="desc"><p>Delete an index from a database. For more info, please refer to
+<a href="https://docs.couchdb.org/en/main/api/database/find.html#db-index">the official documentation</a>.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ddoc</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the design document the index belongs to. A <code>_design/</code> prefix is stripped
+automatically.</dd>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the index.</dd>
+<dt><strong><code>index_type</code></strong> :&ensp;<code>str</code></dt>
+<dd>Can be <code>json</code> or <code>text</code>. Defaults to <code>json</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> upon successful deletion.</p></div>
+</dd>
+<dt id="couchdb3.aio.AsyncDatabase.design_docs"><code class="name flex">
+<span>async def <span class="ident">design_docs</span></span>(<span>self,<br>*,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>endkey: str | None = None,<br>include_docs: bool | None = None,<br>keys: Iterable[str] | None = None,<br>limit: int | None = None,<br>skip: int | None = None,<br>startkey: str | None = None,<br>update_seq: bool | None = None) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def design_docs(
+    self,
+    *,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    endkey: str | None = None,
+    include_docs: bool | None = None,
+    keys: Iterable[str] | None = None,
+    limit: int | None = None,
+    skip: int | None = None,
+    startkey: str | None = None,
+    update_seq: bool | None = None,
+) -&gt; ViewResult:
+    &#34;&#34;&#34;
+    Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+    This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+    Parameters
+    ----------
+    conflicts : bool
+        Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+    descending : bool
+        Return the documents in descending order by key. Default is `None`.
+    endkey : str
+        Stop returning records when the specified key is reached. Default is `None`.
+    include_docs : bool
+        Include the associated document with each row. Default is `None`.
+    keys : Iterable[str]
+        Return only documents where the key matches one of the keys specified in the argument.
+        Default is `None`.
+    limit : int
+        Limit the number of the returned documents. Default is `None`.
+    skip : int
+        Skip this number of records before starting to return the results. Default is `None`.
+    startkey : str
+        Return records starting with the specified key. Default is `None`.
+    update_seq : bool
+        Whether to include an `update_seq` value indicating the sequence id of the database.
+        Default is `None`.
+
+    Returns
+    -------
+    ViewResult
+    &#34;&#34;&#34;
+    return ViewResult(
+        **(
+            await self._get(
+                resource=&#34;_design_docs&#34;,
+                query_kwargs=rm_nones_from_dict(
+                    {
+                        &#34;conflicts&#34;: conflicts,
+                        &#34;descending&#34;: descending,
+                        &#34;endkey&#34;: endkey,
+                        &#34;include_docs&#34;: include_docs,
+                        &#34;keys&#34;: keys,
+                        &#34;limit&#34;: limit,
+                        &#34;skip&#34;: skip,
+                        &#34;startkey&#34;: startkey,
+                        &#34;update_seq&#34;: update_seq,
+                    }
+                ),
+            )
+        ).json()
+    )</code></pre>
+</details>
+<div class="desc"><p>Executes the built-in <code>_design_docs</code> view, returning all the design documents in the database.</p>
+<p>This is a shorthand for <code>_all_docs</code> filtered to the <code>_design/</code> key range.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Ignored if <code>include_docs</code> isn't <code>True</code>. Default is <code>None</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return the documents in descending order by key. Default is <code>None</code>.</dd>
+<dt><strong><code>endkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Stop returning records when the specified key is reached. Default is <code>None</code>.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each row. Default is <code>None</code>.</dd>
+<dt><strong><code>keys</code></strong> :&ensp;<code>Iterable[str]</code></dt>
+<dd>Return only documents where the key matches one of the keys specified in the argument.
+Default is <code>None</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Limit the number of the returned documents. Default is <code>None</code>.</dd>
+<dt><strong><code>skip</code></strong> :&ensp;<code>int</code></dt>
+<dd>Skip this number of records before starting to return the results. Default is <code>None</code>.</dd>
+<dt><strong><code>startkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return records starting with the specified key. Default is <code>None</code>.</dd>
+<dt><strong><code>update_seq</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Whether to include an <code>update_seq</code> value indicating the sequence id of the database.
+Default is <code>None</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>ViewResult</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
 <dt id="couchdb3.aio.AsyncDatabase.explain"><code class="name flex">
 <span>async def <span class="ident">explain</span></span>(<span>self,<br>selector: dict,<br>limit: int = 25,<br>skip: int = 0,<br>sort: list[dict] | None = None,<br>fields: list[str] | None = None,<br>use_index: str | list[str] | None = None,<br>conflicts: bool = False,<br>r: int = 1,<br>bookmark: str | None = None,<br>update: bool = True,<br>stable: bool | None = None,<br>execution_stats: bool = False) ‑> dict</span>
 </code></dt>
@@ -2612,7 +2850,7 @@ Default <code>None</code>.</dd>
     tuple[str, bool, str] : (id, ok, rev)
     &#34;&#34;&#34;
     if partitioned:
-        options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+        options = {**(options or {}), &#34;partitioned&#34;: partitioned}
     return await self.save(
         doc=rm_nones_from_dict(
             {
@@ -3288,7 +3526,7 @@ Default <code>None</code>.</dd>
     async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
         &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
         return await super().bulk_get(
-            docs=[self.add_partition_to_doc(doc) for doc in docs],
+            docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
             revs=revs,
         )
 
@@ -3424,7 +3662,7 @@ Default <code>None</code>.</dd>
 
     def add_partition_to_str(self, string: str) -&gt; str:
         &#34;&#34;&#34;Append the instance&#39;s partition ID to a string if not already present.&#34;&#34;&#34;
-        if string.startswith(self.partition_id):
+        if string.startswith(f&#34;{self.partition_id}:&#34;):
             return string
         return f&#34;{self.partition_id}:{string}&#34;
 
@@ -3434,6 +3672,14 @@ Default <code>None</code>.</dd>
         if docid is None:
             return doc
         doc[&#34;_id&#34;] = self.add_partition_to_str(docid)
+        return doc
+
+    def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+        &#34;&#34;&#34;Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).&#34;&#34;&#34;
+        key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+        if key is None:
+            return doc
+        doc[key] = self.add_partition_to_str(doc[key])
         return doc</code></pre>
 </details>
 <div class="desc"><p>Async CouchDB partition client. Mirrors <code>Partition</code> with <code>async def</code> methods throughout.</p>
@@ -3504,6 +3750,24 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="couchdb3.aio.AsyncPartition.add_partition_to_bulk_get_doc"><code class="name flex">
+<span>def <span class="ident">add_partition_to_bulk_get_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+    &#34;&#34;&#34;Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).&#34;&#34;&#34;
+    key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+    if key is None:
+        return doc
+    doc[key] = self.add_partition_to_str(doc[key])
+    return doc</code></pre>
+</details>
+<div class="desc"><p>Append the instance's partition ID to a <code>bulk_get</code> document's <code>id</code> (or <code>_id</code>).</p></div>
+</dd>
 <dt id="couchdb3.aio.AsyncPartition.add_partition_to_doc"><code class="name flex">
 <span>def <span class="ident">add_partition_to_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
 </code></dt>
@@ -3532,7 +3796,7 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
 </summary>
 <pre><code class="python">def add_partition_to_str(self, string: str) -&gt; str:
     &#34;&#34;&#34;Append the instance&#39;s partition ID to a string if not already present.&#34;&#34;&#34;
-    if string.startswith(self.partition_id):
+    if string.startswith(f&#34;{self.partition_id}:&#34;):
         return string
     return f&#34;{self.partition_id}:{string}&#34;</code></pre>
 </details>
@@ -3605,7 +3869,7 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
 <pre><code class="python">async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -&gt; list[dict]:
     &#34;&#34;&#34;See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs.&#34;&#34;&#34;
     return await super().bulk_get(
-        docs=[self.add_partition_to_doc(doc) for doc in docs],
+        docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
         revs=revs,
     )</code></pre>
 </details>
@@ -3976,6 +4240,8 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.changes" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.changes">changes</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.check" href="async_base.html#couchdb3.aio.async_base.AsyncBase.check">check</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.compact" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.compact">compact</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.delete_index" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.aio.async_database.AsyncDatabase.design_docs" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.explain" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.explain">explain</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.get_design" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.get_design">get_design</a></code></li>
 <li><code><a title="couchdb3.aio.async_database.AsyncDatabase.get_partition" href="async_database.html#couchdb3.aio.async_database.AsyncDatabase.get_partition">get_partition</a></code></li>
@@ -4311,6 +4577,29 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
         await self._delete(resource=resource)
         return True
 
+    async def has_db(self, name: str) -&gt; bool:
+        &#34;&#34;&#34;
+        Check if the server contains a database with the given name.
+
+        Note:
+        The async client cannot support the `name in server` syntax (Python does not allow
+        `__contains__` to be a coroutine). Use `await client.has_db(name)` instead.
+
+        Parameters
+        ----------
+        name : str
+            The database&#39;s name.
+
+        Returns
+        -------
+        bool : `True` if the database exists, otherwise `False`.
+        &#34;&#34;&#34;
+        try:
+            await self._head(resource=name)
+            return True
+        except CouchDBError:
+            return False
+
     async def replicate(
         self,
         source: dict | str,
@@ -4337,7 +4626,8 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
         target : dict | str
             Fully qualified target database URL or an object with URL and headers.
         replication_id : str
-            The ID of the replication document.
+            Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+            a replication document ID).
         cancel : bool
             Cancels the replication.
         continuous : bool
@@ -4371,10 +4661,9 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
             )
         return (
             await self._post(
-                resource=&#34;_replicator&#34;,
+                resource=&#34;_replicate&#34;,
                 body=rm_nones_from_dict(
                     {
-                        &#34;_id&#34;: replication_id,
                         &#34;source&#34;: source,
                         &#34;target&#34;: target,
                         &#34;cancel&#34;: cancel,
@@ -4382,7 +4671,7 @@ partition was constructed directly (i.e. not via <code><a title="couchdb3.aio.As
                         &#34;create_target&#34;: create_target,
                         &#34;create_target_params&#34;: create_target_params,
                         &#34;doc_ids&#34;: doc_ids,
-                        &#34;filter_func&#34;: filter_func,
+                        &#34;filter&#34;: filter_func,
                         &#34;selector&#34;: selector,
                         &#34;source_proxy&#34;: source_proxy,
                         &#34;target_proxy&#34;: target_proxy,
@@ -5128,6 +5417,49 @@ Defaults to <code>["_users", "_replicator"]</code>.</dd>
 <dd>&nbsp;</dd>
 </dl></div>
 </dd>
+<dt id="couchdb3.aio.AsyncServer.has_db"><code class="name flex">
+<span>async def <span class="ident">has_db</span></span>(<span>self, name: str) ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def has_db(self, name: str) -&gt; bool:
+    &#34;&#34;&#34;
+    Check if the server contains a database with the given name.
+
+    Note:
+    The async client cannot support the `name in server` syntax (Python does not allow
+    `__contains__` to be a coroutine). Use `await client.has_db(name)` instead.
+
+    Parameters
+    ----------
+    name : str
+        The database&#39;s name.
+
+    Returns
+    -------
+    bool : `True` if the database exists, otherwise `False`.
+    &#34;&#34;&#34;
+    try:
+        await self._head(resource=name)
+        return True
+    except CouchDBError:
+        return False</code></pre>
+</details>
+<div class="desc"><p>Check if the server contains a database with the given name.</p>
+<p>Note:
+The async client cannot support the <code>name in server</code> syntax (Python does not allow
+<code>__contains__</code> to be a coroutine). Use <code>await client.has_db(name)</code> instead.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>The database's name.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> if the database exists, otherwise <code>False</code>.</p></div>
+</dd>
 <dt id="couchdb3.aio.AsyncServer.membership"><code class="name flex">
 <span>async def <span class="ident">membership</span></span>(<span>self) ‑> dict</span>
 </code></dt>
@@ -5369,7 +5701,8 @@ that have not been written to disk.</p>
     target : dict | str
         Fully qualified target database URL or an object with URL and headers.
     replication_id : str
-        The ID of the replication document.
+        Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+        a replication document ID).
     cancel : bool
         Cancels the replication.
     continuous : bool
@@ -5403,10 +5736,9 @@ that have not been written to disk.</p>
         )
     return (
         await self._post(
-            resource=&#34;_replicator&#34;,
+            resource=&#34;_replicate&#34;,
             body=rm_nones_from_dict(
                 {
-                    &#34;_id&#34;: replication_id,
                     &#34;source&#34;: source,
                     &#34;target&#34;: target,
                     &#34;cancel&#34;: cancel,
@@ -5414,7 +5746,7 @@ that have not been written to disk.</p>
                     &#34;create_target&#34;: create_target,
                     &#34;create_target_params&#34;: create_target_params,
                     &#34;doc_ids&#34;: doc_ids,
-                    &#34;filter_func&#34;: filter_func,
+                    &#34;filter&#34;: filter_func,
                     &#34;selector&#34;: selector,
                     &#34;source_proxy&#34;: source_proxy,
                     &#34;target_proxy&#34;: target_proxy,
@@ -5432,7 +5764,8 @@ that have not been written to disk.</p>
 <dt><strong><code>target</code></strong> :&ensp;<code>dict | str</code></dt>
 <dd>Fully qualified target database URL or an object with URL and headers.</dd>
 <dt><strong><code>replication_id</code></strong> :&ensp;<code>str</code></dt>
-<dd>The ID of the replication document.</dd>
+<dd>Deprecated. Ignored for one-shot replication (the <code>_replicate</code> endpoint does not accept
+a replication document ID).</dd>
 <dt><strong><code>cancel</code></strong> :&ensp;<code>bool</code></dt>
 <dd>Cancels the replication.</dd>
 <dt><strong><code>continuous</code></strong> :&ensp;<code>bool</code></dt>
@@ -5833,6 +6166,8 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.aio.AsyncDatabase.create" href="#couchdb3.aio.AsyncDatabase.create">create</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.delete" href="#couchdb3.aio.AsyncDatabase.delete">delete</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.delete_attachment" href="#couchdb3.aio.AsyncDatabase.delete_attachment">delete_attachment</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncDatabase.delete_index" href="#couchdb3.aio.AsyncDatabase.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncDatabase.design_docs" href="#couchdb3.aio.AsyncDatabase.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.explain" href="#couchdb3.aio.AsyncDatabase.explain">explain</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.find" href="#couchdb3.aio.AsyncDatabase.find">find</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncDatabase.get" href="#couchdb3.aio.AsyncDatabase.get">get</a></code></li>
@@ -5854,6 +6189,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li>
 <h4><code><a title="couchdb3.aio.AsyncPartition" href="#couchdb3.aio.AsyncPartition">AsyncPartition</a></code></h4>
 <ul class="">
+<li><code><a title="couchdb3.aio.AsyncPartition.add_partition_to_bulk_get_doc" href="#couchdb3.aio.AsyncPartition.add_partition_to_bulk_get_doc">add_partition_to_bulk_get_doc</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.add_partition_to_doc" href="#couchdb3.aio.AsyncPartition.add_partition_to_doc">add_partition_to_doc</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.add_partition_to_str" href="#couchdb3.aio.AsyncPartition.add_partition_to_str">add_partition_to_str</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncPartition.all_docs" href="#couchdb3.aio.AsyncPartition.all_docs">all_docs</a></code></li>
@@ -5886,6 +6222,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.aio.AsyncServer.delete" href="#couchdb3.aio.AsyncServer.delete">delete</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.delete_node_config" href="#couchdb3.aio.AsyncServer.delete_node_config">delete_node_config</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.get" href="#couchdb3.aio.AsyncServer.get">get</a></code></li>
+<li><code><a title="couchdb3.aio.AsyncServer.has_db" href="#couchdb3.aio.AsyncServer.has_db">has_db</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.membership" href="#couchdb3.aio.AsyncServer.membership">membership</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.node_config" href="#couchdb3.aio.AsyncServer.node_config">node_config</a></code></li>
 <li><code><a title="couchdb3.aio.AsyncServer.node_stats" href="#couchdb3.aio.AsyncServer.node_stats">node_stats</a></code></li>

--- a/docs/sync/base.html
+++ b/docs/sync/base.html
@@ -516,10 +516,10 @@ el.replaceWith(d);
         try:
             # httpx.Client.cookies.jar yields http.cookiejar.Cookie objects which
             # carry the .name and .expires attributes we need.
-            return (
-                next(_.expires for _ in self.session.cookies.jar if _.name == &#34;AuthSession&#34;)
-                &lt;= datetime.now(UTC).timestamp()
-            )
+            expires = next(_.expires for _ in self.session.cookies.jar if _.name == &#34;AuthSession&#34;)
+            if expires is None:
+                return False
+            return expires &lt;= datetime.now(UTC).timestamp()
         except StopIteration:
             return True
 

--- a/docs/sync/database.html
+++ b/docs/sync/database.html
@@ -187,6 +187,70 @@ el.replaceWith(d);
             **kwargs,
         )
 
+    def design_docs(
+        self,
+        *,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        endkey: str | None = None,
+        include_docs: bool | None = None,
+        keys: Iterable[str] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+        startkey: str | None = None,
+        update_seq: bool | None = None,
+    ) -&gt; ViewResult:
+        &#34;&#34;&#34;
+        Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+        This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+        Parameters
+        ----------
+        conflicts : bool
+            Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+        descending : bool
+            Return the documents in descending order by key. Default is `None`.
+        endkey : str
+            Stop returning records when the specified key is reached. Default is `None`.
+        include_docs : bool
+            Include the associated document with each row. Default is `None`.
+        keys : Iterable[str]
+            Return only documents where the key matches one of the keys specified in the argument.
+            Default is `None`.
+        limit : int
+            Limit the number of the returned documents. Default is `None`.
+        skip : int
+            Skip this number of records before starting to return the results. Default is `None`.
+        startkey : str
+            Return records starting with the specified key. Default is `None`.
+        update_seq : bool
+            Whether to include an `update_seq` value indicating the sequence id of the database.
+            Default is `None`.
+
+        Returns
+        -------
+        ViewResult
+        &#34;&#34;&#34;
+        return ViewResult(
+            **self._get(
+                resource=&#34;_design_docs&#34;,
+                query_kwargs=rm_nones_from_dict(
+                    {
+                        &#34;conflicts&#34;: conflicts,
+                        &#34;descending&#34;: descending,
+                        &#34;endkey&#34;: endkey,
+                        &#34;include_docs&#34;: include_docs,
+                        &#34;keys&#34;: keys,
+                        &#34;limit&#34;: limit,
+                        &#34;skip&#34;: skip,
+                        &#34;startkey&#34;: startkey,
+                        &#34;update_seq&#34;: update_seq,
+                    }
+                ),
+            ).json()
+        )
+
     def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;
         The bulk document API allows you to create and update multiple documents at the same time within a single
@@ -873,7 +937,7 @@ el.replaceWith(d);
         ... })
         &#34;&#34;&#34;
         if partitioned:
-            options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+            options = {**(options or {}), &#34;partitioned&#34;: partitioned}
         return self.save(
             doc=rm_nones_from_dict(
                 {
@@ -918,9 +982,6 @@ el.replaceWith(d);
         Returns
         -------
         Tuple[str, bool, str] : The document&#39;s id ( `str`), the operation status (`bool`) and the revision ( `str`).
-        &#34;&#34;&#34;
-        &#34;&#34;&#34;
-        :return: 
         &#34;&#34;&#34;
         batch = &#34;ok&#34; if batch else None
         data = self._put(
@@ -994,6 +1055,28 @@ el.replaceWith(d);
             ),
         ).json()
         return data[&#34;result&#34;], data[&#34;id&#34;], data[&#34;name&#34;]
+
+    def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Delete an index from a database. For more info, please refer to
+        [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+        Parameters
+        ----------
+        ddoc : str
+            Name of the design document the index belongs to. A `_design/` prefix is stripped
+            automatically.
+        name : str
+            Name of the index.
+        index_type : str
+            Can be `json` or `text`. Defaults to `json`.
+
+        Returns
+        -------
+        bool : `True` upon successful deletion.
+        &#34;&#34;&#34;
+        ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+        return self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;).json().get(&#34;ok&#34;)
 
     def security(self) -&gt; SecurityDocument:
         &#34;&#34;&#34;
@@ -2062,6 +2145,154 @@ database. For more info, please refer to
 <h2 id="returns">Returns</h2>
 <p>bool : <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.sync.database.Database.delete_index"><code class="name flex">
+<span>def <span class="ident">delete_index</span></span>(<span>self, ddoc: str, name: str, index_type: str = 'json') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Delete an index from a database. For more info, please refer to
+    [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+    Parameters
+    ----------
+    ddoc : str
+        Name of the design document the index belongs to. A `_design/` prefix is stripped
+        automatically.
+    name : str
+        Name of the index.
+    index_type : str
+        Can be `json` or `text`. Defaults to `json`.
+
+    Returns
+    -------
+    bool : `True` upon successful deletion.
+    &#34;&#34;&#34;
+    ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+    return self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;).json().get(&#34;ok&#34;)</code></pre>
+</details>
+<div class="desc"><p>Delete an index from a database. For more info, please refer to
+<a href="https://docs.couchdb.org/en/main/api/database/find.html#db-index">the official documentation</a>.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ddoc</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the design document the index belongs to. A <code>_design/</code> prefix is stripped
+automatically.</dd>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the index.</dd>
+<dt><strong><code>index_type</code></strong> :&ensp;<code>str</code></dt>
+<dd>Can be <code>json</code> or <code>text</code>. Defaults to <code>json</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> upon successful deletion.</p></div>
+</dd>
+<dt id="couchdb3.sync.database.Database.design_docs"><code class="name flex">
+<span>def <span class="ident">design_docs</span></span>(<span>self,<br>*,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>endkey: str | None = None,<br>include_docs: bool | None = None,<br>keys: Iterable[str] | None = None,<br>limit: int | None = None,<br>skip: int | None = None,<br>startkey: str | None = None,<br>update_seq: bool | None = None) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def design_docs(
+    self,
+    *,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    endkey: str | None = None,
+    include_docs: bool | None = None,
+    keys: Iterable[str] | None = None,
+    limit: int | None = None,
+    skip: int | None = None,
+    startkey: str | None = None,
+    update_seq: bool | None = None,
+) -&gt; ViewResult:
+    &#34;&#34;&#34;
+    Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+    This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+    Parameters
+    ----------
+    conflicts : bool
+        Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+    descending : bool
+        Return the documents in descending order by key. Default is `None`.
+    endkey : str
+        Stop returning records when the specified key is reached. Default is `None`.
+    include_docs : bool
+        Include the associated document with each row. Default is `None`.
+    keys : Iterable[str]
+        Return only documents where the key matches one of the keys specified in the argument.
+        Default is `None`.
+    limit : int
+        Limit the number of the returned documents. Default is `None`.
+    skip : int
+        Skip this number of records before starting to return the results. Default is `None`.
+    startkey : str
+        Return records starting with the specified key. Default is `None`.
+    update_seq : bool
+        Whether to include an `update_seq` value indicating the sequence id of the database.
+        Default is `None`.
+
+    Returns
+    -------
+    ViewResult
+    &#34;&#34;&#34;
+    return ViewResult(
+        **self._get(
+            resource=&#34;_design_docs&#34;,
+            query_kwargs=rm_nones_from_dict(
+                {
+                    &#34;conflicts&#34;: conflicts,
+                    &#34;descending&#34;: descending,
+                    &#34;endkey&#34;: endkey,
+                    &#34;include_docs&#34;: include_docs,
+                    &#34;keys&#34;: keys,
+                    &#34;limit&#34;: limit,
+                    &#34;skip&#34;: skip,
+                    &#34;startkey&#34;: startkey,
+                    &#34;update_seq&#34;: update_seq,
+                }
+            ),
+        ).json()
+    )</code></pre>
+</details>
+<div class="desc"><p>Executes the built-in <code>_design_docs</code> view, returning all the design documents in the database.</p>
+<p>This is a shorthand for <code>_all_docs</code> filtered to the <code>_design/</code> key range.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Ignored if <code>include_docs</code> isn't <code>True</code>. Default is <code>None</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return the documents in descending order by key. Default is <code>None</code>.</dd>
+<dt><strong><code>endkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Stop returning records when the specified key is reached. Default is <code>None</code>.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each row. Default is <code>None</code>.</dd>
+<dt><strong><code>keys</code></strong> :&ensp;<code>Iterable[str]</code></dt>
+<dd>Return only documents where the key matches one of the keys specified in the argument.
+Default is <code>None</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Limit the number of the returned documents. Default is <code>None</code>.</dd>
+<dt><strong><code>skip</code></strong> :&ensp;<code>int</code></dt>
+<dd>Skip this number of records before starting to return the results. Default is <code>None</code>.</dd>
+<dt><strong><code>startkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return records starting with the specified key. Default is <code>None</code>.</dd>
+<dt><strong><code>update_seq</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Whether to include an <code>update_seq</code> value indicating the sequence id of the database.
+Default is <code>None</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>ViewResult</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
 <dt id="couchdb3.sync.database.Database.explain"><code class="name flex">
 <span>def <span class="ident">explain</span></span>(<span>self,<br>selector: dict,<br>limit: int = 25,<br>skip: int = 0,<br>sort: list[dict] | None = None,<br>fields: list[str] | None = None,<br>use_index: str | list[str] | None = None,<br>conflicts: bool = False,<br>r: int = 1,<br>bookmark: str | None = None,<br>update: bool = True,<br>stable: bool | None = None,<br>execution_stats: bool = False) ‑> dict</span>
 </code></dt>
@@ -2888,7 +3119,7 @@ Must be provided when passing the <code>content</code> argument.</dd>
     ... })
     &#34;&#34;&#34;
     if partitioned:
-        options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+        options = {**(options or {}), &#34;partitioned&#34;: partitioned}
     return self.save(
         doc=rm_nones_from_dict(
             {
@@ -2980,9 +3211,6 @@ design document functions.</dd>
     Returns
     -------
     Tuple[str, bool, str] : The document&#39;s id ( `str`), the operation status (`bool`) and the revision ( `str`).
-    &#34;&#34;&#34;
-    &#34;&#34;&#34;
-    :return: 
     &#34;&#34;&#34;
     batch = &#34;ok&#34; if batch else None
     data = self._put(
@@ -3618,7 +3846,6 @@ ViewResult: {
         ddoc: str,
         view: str | None = None,
         *,
-        # partition: str = None,
         conflicts: bool | None = None,
         descending: bool | None = None,
         endkey: Any | None = None,
@@ -3761,7 +3988,7 @@ ViewResult: {
         Appends the partition&#39;s ID to the documents&#39; ID.
         &#34;&#34;&#34;
         return super().bulk_get(
-            docs=[self.add_partition_to_doc(doc) for doc in docs],
+            docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
             revs=revs,
         )
 
@@ -3961,7 +4188,7 @@ ViewResult: {
         &#34;&#34;&#34;
         Append the instance&#39;s partition ID to a string.
         &#34;&#34;&#34;
-        if string.startswith(self.partition_id):
+        if string.startswith(f&#34;{self.partition_id}:&#34;):
             return string
         return f&#34;{self.partition_id}:{string}&#34;
 
@@ -3973,6 +4200,16 @@ ViewResult: {
         if docid is None:
             return doc
         doc[&#34;_id&#34;] = self.add_partition_to_str(docid)
+        return doc
+
+    def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+        &#34;&#34;&#34;
+        Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).
+        &#34;&#34;&#34;
+        key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+        if key is None:
+            return doc
+        doc[key] = self.add_partition_to_str(doc[key])
         return doc</code></pre>
 </details>
 <div class="desc"><p>Abstract Couchdb partition</p>
@@ -4047,6 +4284,26 @@ was constructed directly (i.e. not via <code><a title="couchdb3.sync.database.Da
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="couchdb3.sync.database.Partition.add_partition_to_bulk_get_doc"><code class="name flex">
+<span>def <span class="ident">add_partition_to_bulk_get_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+    &#34;&#34;&#34;
+    Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).
+    &#34;&#34;&#34;
+    key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+    if key is None:
+        return doc
+    doc[key] = self.add_partition_to_str(doc[key])
+    return doc</code></pre>
+</details>
+<div class="desc"><p>Append the instance's partition ID to a <code>bulk_get</code> document's <code>id</code> (or <code>_id</code>).</p></div>
+</dd>
 <dt id="couchdb3.sync.database.Partition.add_partition_to_doc"><code class="name flex">
 <span>def <span class="ident">add_partition_to_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
 </code></dt>
@@ -4079,7 +4336,7 @@ was constructed directly (i.e. not via <code><a title="couchdb3.sync.database.Da
     &#34;&#34;&#34;
     Append the instance&#39;s partition ID to a string.
     &#34;&#34;&#34;
-    if string.startswith(self.partition_id):
+    if string.startswith(f&#34;{self.partition_id}:&#34;):
         return string
     return f&#34;{self.partition_id}:{string}&#34;</code></pre>
 </details>
@@ -4168,7 +4425,7 @@ Appends the partition's ID to the documents' ID.</p></div>
     Appends the partition&#39;s ID to the documents&#39; ID.
     &#34;&#34;&#34;
     return super().bulk_get(
-        docs=[self.add_partition_to_doc(doc) for doc in docs],
+        docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
         revs=revs,
     )</code></pre>
 </details>
@@ -4552,7 +4809,6 @@ Appends the partition's ID to the document's ID.</p></div>
     ddoc: str,
     view: str | None = None,
     *,
-    # partition: str = None,
     conflicts: bool | None = None,
     descending: bool | None = None,
     endkey: Any | None = None,
@@ -4748,6 +5004,8 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.changes" href="#couchdb3.sync.database.Database.changes">changes</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.check" href="base.html#couchdb3.sync.base.Base.check">check</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.compact" href="#couchdb3.sync.database.Database.compact">compact</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.delete_index" href="#couchdb3.sync.database.Database.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.design_docs" href="#couchdb3.sync.database.Database.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.explain" href="#couchdb3.sync.database.Database.explain">explain</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.get_design" href="#couchdb3.sync.database.Database.get_design">get_design</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.get_partition" href="#couchdb3.sync.database.Database.get_partition">get_partition</a></code></li>
@@ -4790,6 +5048,8 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.create" href="#couchdb3.sync.database.Database.create">create</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.delete" href="#couchdb3.sync.database.Database.delete">delete</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.delete_attachment" href="#couchdb3.sync.database.Database.delete_attachment">delete_attachment</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.delete_index" href="#couchdb3.sync.database.Database.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.design_docs" href="#couchdb3.sync.database.Database.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.explain" href="#couchdb3.sync.database.Database.explain">explain</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.find" href="#couchdb3.sync.database.Database.find">find</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.get" href="#couchdb3.sync.database.Database.get">get</a></code></li>
@@ -4811,6 +5071,7 @@ view reflects. Default is <code>False</code>.</dd>
 <li>
 <h4><code><a title="couchdb3.sync.database.Partition" href="#couchdb3.sync.database.Partition">Partition</a></code></h4>
 <ul class="">
+<li><code><a title="couchdb3.sync.database.Partition.add_partition_to_bulk_get_doc" href="#couchdb3.sync.database.Partition.add_partition_to_bulk_get_doc">add_partition_to_bulk_get_doc</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.add_partition_to_doc" href="#couchdb3.sync.database.Partition.add_partition_to_doc">add_partition_to_doc</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.add_partition_to_str" href="#couchdb3.sync.database.Partition.add_partition_to_str">add_partition_to_str</a></code></li>
 <li><code><a title="couchdb3.sync.database.Partition.all_docs" href="#couchdb3.sync.database.Partition.all_docs">all_docs</a></code></li>

--- a/docs/sync/index.html
+++ b/docs/sync/index.html
@@ -207,6 +207,70 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             **kwargs,
         )
 
+    def design_docs(
+        self,
+        *,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        endkey: str | None = None,
+        include_docs: bool | None = None,
+        keys: Iterable[str] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+        startkey: str | None = None,
+        update_seq: bool | None = None,
+    ) -&gt; ViewResult:
+        &#34;&#34;&#34;
+        Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+        This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+        Parameters
+        ----------
+        conflicts : bool
+            Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+        descending : bool
+            Return the documents in descending order by key. Default is `None`.
+        endkey : str
+            Stop returning records when the specified key is reached. Default is `None`.
+        include_docs : bool
+            Include the associated document with each row. Default is `None`.
+        keys : Iterable[str]
+            Return only documents where the key matches one of the keys specified in the argument.
+            Default is `None`.
+        limit : int
+            Limit the number of the returned documents. Default is `None`.
+        skip : int
+            Skip this number of records before starting to return the results. Default is `None`.
+        startkey : str
+            Return records starting with the specified key. Default is `None`.
+        update_seq : bool
+            Whether to include an `update_seq` value indicating the sequence id of the database.
+            Default is `None`.
+
+        Returns
+        -------
+        ViewResult
+        &#34;&#34;&#34;
+        return ViewResult(
+            **self._get(
+                resource=&#34;_design_docs&#34;,
+                query_kwargs=rm_nones_from_dict(
+                    {
+                        &#34;conflicts&#34;: conflicts,
+                        &#34;descending&#34;: descending,
+                        &#34;endkey&#34;: endkey,
+                        &#34;include_docs&#34;: include_docs,
+                        &#34;keys&#34;: keys,
+                        &#34;limit&#34;: limit,
+                        &#34;skip&#34;: skip,
+                        &#34;startkey&#34;: startkey,
+                        &#34;update_seq&#34;: update_seq,
+                    }
+                ),
+            ).json()
+        )
+
     def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -&gt; list[dict]:
         &#34;&#34;&#34;
         The bulk document API allows you to create and update multiple documents at the same time within a single
@@ -893,7 +957,7 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         ... })
         &#34;&#34;&#34;
         if partitioned:
-            options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+            options = {**(options or {}), &#34;partitioned&#34;: partitioned}
         return self.save(
             doc=rm_nones_from_dict(
                 {
@@ -938,9 +1002,6 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
         Returns
         -------
         Tuple[str, bool, str] : The document&#39;s id ( `str`), the operation status (`bool`) and the revision ( `str`).
-        &#34;&#34;&#34;
-        &#34;&#34;&#34;
-        :return: 
         &#34;&#34;&#34;
         batch = &#34;ok&#34; if batch else None
         data = self._put(
@@ -1014,6 +1075,28 @@ re-exported here — import them from <code><a title="couchdb3" href="../index.h
             ),
         ).json()
         return data[&#34;result&#34;], data[&#34;id&#34;], data[&#34;name&#34;]
+
+    def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+        &#34;&#34;&#34;
+        Delete an index from a database. For more info, please refer to
+        [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+        Parameters
+        ----------
+        ddoc : str
+            Name of the design document the index belongs to. A `_design/` prefix is stripped
+            automatically.
+        name : str
+            Name of the index.
+        index_type : str
+            Can be `json` or `text`. Defaults to `json`.
+
+        Returns
+        -------
+        bool : `True` upon successful deletion.
+        &#34;&#34;&#34;
+        ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+        return self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;).json().get(&#34;ok&#34;)
 
     def security(self) -&gt; SecurityDocument:
         &#34;&#34;&#34;
@@ -2082,6 +2165,154 @@ database. For more info, please refer to
 <h2 id="returns">Returns</h2>
 <p>bool : <code>True</code> upon successful deletion.</p></div>
 </dd>
+<dt id="couchdb3.sync.Database.delete_index"><code class="name flex">
+<span>def <span class="ident">delete_index</span></span>(<span>self, ddoc: str, name: str, index_type: str = 'json') ‑> bool</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def delete_index(self, ddoc: str, name: str, index_type: str = &#34;json&#34;) -&gt; bool:
+    &#34;&#34;&#34;
+    Delete an index from a database. For more info, please refer to
+    [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+    Parameters
+    ----------
+    ddoc : str
+        Name of the design document the index belongs to. A `_design/` prefix is stripped
+        automatically.
+    name : str
+        Name of the index.
+    index_type : str
+        Can be `json` or `text`. Defaults to `json`.
+
+    Returns
+    -------
+    bool : `True` upon successful deletion.
+    &#34;&#34;&#34;
+    ddoc = ddoc.removeprefix(&#34;_design/&#34;)
+    return self._delete(resource=f&#34;_index/{ddoc}/{index_type}/{name}&#34;).json().get(&#34;ok&#34;)</code></pre>
+</details>
+<div class="desc"><p>Delete an index from a database. For more info, please refer to
+<a href="https://docs.couchdb.org/en/main/api/database/find.html#db-index">the official documentation</a>.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>ddoc</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the design document the index belongs to. A <code>_design/</code> prefix is stripped
+automatically.</dd>
+<dt><strong><code>name</code></strong> :&ensp;<code>str</code></dt>
+<dd>Name of the index.</dd>
+<dt><strong><code>index_type</code></strong> :&ensp;<code>str</code></dt>
+<dd>Can be <code>json</code> or <code>text</code>. Defaults to <code>json</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<p>bool : <code>True</code> upon successful deletion.</p></div>
+</dd>
+<dt id="couchdb3.sync.Database.design_docs"><code class="name flex">
+<span>def <span class="ident">design_docs</span></span>(<span>self,<br>*,<br>conflicts: bool | None = None,<br>descending: bool | None = None,<br>endkey: str | None = None,<br>include_docs: bool | None = None,<br>keys: Iterable[str] | None = None,<br>limit: int | None = None,<br>skip: int | None = None,<br>startkey: str | None = None,<br>update_seq: bool | None = None) ‑> <a title="couchdb3.view.ViewResult" href="../view.html#couchdb3.view.ViewResult">ViewResult</a></span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def design_docs(
+    self,
+    *,
+    conflicts: bool | None = None,
+    descending: bool | None = None,
+    endkey: str | None = None,
+    include_docs: bool | None = None,
+    keys: Iterable[str] | None = None,
+    limit: int | None = None,
+    skip: int | None = None,
+    startkey: str | None = None,
+    update_seq: bool | None = None,
+) -&gt; ViewResult:
+    &#34;&#34;&#34;
+    Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+    This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+    Parameters
+    ----------
+    conflicts : bool
+        Include conflicts information. Ignored if `include_docs` isn&#39;t `True`. Default is `None`.
+    descending : bool
+        Return the documents in descending order by key. Default is `None`.
+    endkey : str
+        Stop returning records when the specified key is reached. Default is `None`.
+    include_docs : bool
+        Include the associated document with each row. Default is `None`.
+    keys : Iterable[str]
+        Return only documents where the key matches one of the keys specified in the argument.
+        Default is `None`.
+    limit : int
+        Limit the number of the returned documents. Default is `None`.
+    skip : int
+        Skip this number of records before starting to return the results. Default is `None`.
+    startkey : str
+        Return records starting with the specified key. Default is `None`.
+    update_seq : bool
+        Whether to include an `update_seq` value indicating the sequence id of the database.
+        Default is `None`.
+
+    Returns
+    -------
+    ViewResult
+    &#34;&#34;&#34;
+    return ViewResult(
+        **self._get(
+            resource=&#34;_design_docs&#34;,
+            query_kwargs=rm_nones_from_dict(
+                {
+                    &#34;conflicts&#34;: conflicts,
+                    &#34;descending&#34;: descending,
+                    &#34;endkey&#34;: endkey,
+                    &#34;include_docs&#34;: include_docs,
+                    &#34;keys&#34;: keys,
+                    &#34;limit&#34;: limit,
+                    &#34;skip&#34;: skip,
+                    &#34;startkey&#34;: startkey,
+                    &#34;update_seq&#34;: update_seq,
+                }
+            ),
+        ).json()
+    )</code></pre>
+</details>
+<div class="desc"><p>Executes the built-in <code>_design_docs</code> view, returning all the design documents in the database.</p>
+<p>This is a shorthand for <code>_all_docs</code> filtered to the <code>_design/</code> key range.</p>
+<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>conflicts</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include conflicts information. Ignored if <code>include_docs</code> isn't <code>True</code>. Default is <code>None</code>.</dd>
+<dt><strong><code>descending</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Return the documents in descending order by key. Default is <code>None</code>.</dd>
+<dt><strong><code>endkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Stop returning records when the specified key is reached. Default is <code>None</code>.</dd>
+<dt><strong><code>include_docs</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Include the associated document with each row. Default is <code>None</code>.</dd>
+<dt><strong><code>keys</code></strong> :&ensp;<code>Iterable[str]</code></dt>
+<dd>Return only documents where the key matches one of the keys specified in the argument.
+Default is <code>None</code>.</dd>
+<dt><strong><code>limit</code></strong> :&ensp;<code>int</code></dt>
+<dd>Limit the number of the returned documents. Default is <code>None</code>.</dd>
+<dt><strong><code>skip</code></strong> :&ensp;<code>int</code></dt>
+<dd>Skip this number of records before starting to return the results. Default is <code>None</code>.</dd>
+<dt><strong><code>startkey</code></strong> :&ensp;<code>str</code></dt>
+<dd>Return records starting with the specified key. Default is <code>None</code>.</dd>
+<dt><strong><code>update_seq</code></strong> :&ensp;<code>bool</code></dt>
+<dd>Whether to include an <code>update_seq</code> value indicating the sequence id of the database.
+Default is <code>None</code>.</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>ViewResult</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+</dd>
 <dt id="couchdb3.sync.Database.explain"><code class="name flex">
 <span>def <span class="ident">explain</span></span>(<span>self,<br>selector: dict,<br>limit: int = 25,<br>skip: int = 0,<br>sort: list[dict] | None = None,<br>fields: list[str] | None = None,<br>use_index: str | list[str] | None = None,<br>conflicts: bool = False,<br>r: int = 1,<br>bookmark: str | None = None,<br>update: bool = True,<br>stable: bool | None = None,<br>execution_stats: bool = False) ‑> dict</span>
 </code></dt>
@@ -2908,7 +3139,7 @@ Must be provided when passing the <code>content</code> argument.</dd>
     ... })
     &#34;&#34;&#34;
     if partitioned:
-        options = (options or {}).update({&#34;partitioned&#34;: partitioned})
+        options = {**(options or {}), &#34;partitioned&#34;: partitioned}
     return self.save(
         doc=rm_nones_from_dict(
             {
@@ -3000,9 +3231,6 @@ design document functions.</dd>
     Returns
     -------
     Tuple[str, bool, str] : The document&#39;s id ( `str`), the operation status (`bool`) and the revision ( `str`).
-    &#34;&#34;&#34;
-    &#34;&#34;&#34;
-    :return: 
     &#34;&#34;&#34;
     batch = &#34;ok&#34; if batch else None
     data = self._put(
@@ -3638,7 +3866,6 @@ ViewResult: {
         ddoc: str,
         view: str | None = None,
         *,
-        # partition: str = None,
         conflicts: bool | None = None,
         descending: bool | None = None,
         endkey: Any | None = None,
@@ -3781,7 +4008,7 @@ ViewResult: {
         Appends the partition&#39;s ID to the documents&#39; ID.
         &#34;&#34;&#34;
         return super().bulk_get(
-            docs=[self.add_partition_to_doc(doc) for doc in docs],
+            docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
             revs=revs,
         )
 
@@ -3981,7 +4208,7 @@ ViewResult: {
         &#34;&#34;&#34;
         Append the instance&#39;s partition ID to a string.
         &#34;&#34;&#34;
-        if string.startswith(self.partition_id):
+        if string.startswith(f&#34;{self.partition_id}:&#34;):
             return string
         return f&#34;{self.partition_id}:{string}&#34;
 
@@ -3993,6 +4220,16 @@ ViewResult: {
         if docid is None:
             return doc
         doc[&#34;_id&#34;] = self.add_partition_to_str(docid)
+        return doc
+
+    def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+        &#34;&#34;&#34;
+        Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).
+        &#34;&#34;&#34;
+        key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+        if key is None:
+            return doc
+        doc[key] = self.add_partition_to_str(doc[key])
         return doc</code></pre>
 </details>
 <div class="desc"><p>Abstract Couchdb partition</p>
@@ -4067,6 +4304,26 @@ was constructed directly (i.e. not via <code><a title="couchdb3.sync.Database.ge
 </dl>
 <h3>Methods</h3>
 <dl>
+<dt id="couchdb3.sync.Partition.add_partition_to_bulk_get_doc"><code class="name flex">
+<span>def <span class="ident">add_partition_to_bulk_get_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
+</code></dt>
+<dd>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def add_partition_to_bulk_get_doc(self, doc: Document | dict) -&gt; Document | dict:
+    &#34;&#34;&#34;
+    Append the instance&#39;s partition ID to a `bulk_get` document&#39;s `id` (or `_id`).
+    &#34;&#34;&#34;
+    key = &#34;_id&#34; if &#34;_id&#34; in doc else &#34;id&#34; if &#34;id&#34; in doc else None
+    if key is None:
+        return doc
+    doc[key] = self.add_partition_to_str(doc[key])
+    return doc</code></pre>
+</details>
+<div class="desc"><p>Append the instance's partition ID to a <code>bulk_get</code> document's <code>id</code> (or <code>_id</code>).</p></div>
+</dd>
 <dt id="couchdb3.sync.Partition.add_partition_to_doc"><code class="name flex">
 <span>def <span class="ident">add_partition_to_doc</span></span>(<span>self, doc: Document | dict) ‑> <a title="couchdb3.document.Document" href="../document.html#couchdb3.document.Document">Document</a> | dict</span>
 </code></dt>
@@ -4099,7 +4356,7 @@ was constructed directly (i.e. not via <code><a title="couchdb3.sync.Database.ge
     &#34;&#34;&#34;
     Append the instance&#39;s partition ID to a string.
     &#34;&#34;&#34;
-    if string.startswith(self.partition_id):
+    if string.startswith(f&#34;{self.partition_id}:&#34;):
         return string
     return f&#34;{self.partition_id}:{string}&#34;</code></pre>
 </details>
@@ -4188,7 +4445,7 @@ Appends the partition's ID to the documents' ID.</p></div>
     Appends the partition&#39;s ID to the documents&#39; ID.
     &#34;&#34;&#34;
     return super().bulk_get(
-        docs=[self.add_partition_to_doc(doc) for doc in docs],
+        docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
         revs=revs,
     )</code></pre>
 </details>
@@ -4572,7 +4829,6 @@ Appends the partition's ID to the document's ID.</p></div>
     ddoc: str,
     view: str | None = None,
     *,
-    # partition: str = None,
     conflicts: bool | None = None,
     descending: bool | None = None,
     endkey: Any | None = None,
@@ -4768,6 +5024,8 @@ view reflects. Default is <code>False</code>.</dd>
 <li><code><a title="couchdb3.sync.database.Database.changes" href="database.html#couchdb3.sync.database.Database.changes">changes</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.check" href="base.html#couchdb3.sync.base.Base.check">check</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.compact" href="database.html#couchdb3.sync.database.Database.compact">compact</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.delete_index" href="database.html#couchdb3.sync.database.Database.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.sync.database.Database.design_docs" href="database.html#couchdb3.sync.database.Database.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.explain" href="database.html#couchdb3.sync.database.Database.explain">explain</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.get_design" href="database.html#couchdb3.sync.database.Database.get_design">get_design</a></code></li>
 <li><code><a title="couchdb3.sync.database.Database.get_partition" href="database.html#couchdb3.sync.database.Database.get_partition">get_partition</a></code></li>
@@ -4850,11 +5108,11 @@ view reflects. Default is <code>False</code>.</dd>
 
     def __repr__(self) -&gt; str:
         &#34;&#34;&#34;
-        Close the session on delete.
+        Basic repr.
 
         Returns
         -------
-        str
+        str : The instance&#39;s representation.
         &#34;&#34;&#34;
         return f&#34;{super().__repr__()}: {self.url}&#34;
 
@@ -5147,7 +5405,8 @@ view reflects. Default is <code>False</code>.</dd>
                 {“url”:”url in here”, “headers”: {“header1”:”value1”, …}}
 
         replication_id : str
-            The ID of the replication document.
+            Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+            a replication document ID).
         cancel : bool
             Cancels the replication.
         continuous : bool
@@ -5193,10 +5452,9 @@ view reflects. Default is <code>False</code>.</dd>
                 &#39;Arguments &#34;doc_ids&#34;, &#34;filter_func&#34; and &#34;selector&#34; are mutually exclusive.&#39;
             )
         return self._post(
-            resource=&#34;_replicator&#34;,
+            resource=&#34;_replicate&#34;,
             body=rm_nones_from_dict(
                 {
-                    &#34;_id&#34;: replication_id,
                     &#34;source&#34;: source,
                     &#34;target&#34;: target,
                     &#34;cancel&#34;: cancel,
@@ -5204,7 +5462,7 @@ view reflects. Default is <code>False</code>.</dd>
                     &#34;create_target&#34;: create_target,
                     &#34;create_target_params&#34;: create_target_params,
                     &#34;doc_ids&#34;: doc_ids,
-                    &#34;filter_func&#34;: filter_func,
+                    &#34;filter&#34;: filter_func,
                     &#34;selector&#34;: selector,
                     &#34;source_proxy&#34;: source_proxy,
                     &#34;target_proxy&#34;: target_proxy,
@@ -6187,7 +6445,8 @@ that have not been written to disk.</p>
             {“url”:”url in here”, “headers”: {“header1”:”value1”, …}}
 
     replication_id : str
-        The ID of the replication document.
+        Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+        a replication document ID).
     cancel : bool
         Cancels the replication.
     continuous : bool
@@ -6233,10 +6492,9 @@ that have not been written to disk.</p>
             &#39;Arguments &#34;doc_ids&#34;, &#34;filter_func&#34; and &#34;selector&#34; are mutually exclusive.&#39;
         )
     return self._post(
-        resource=&#34;_replicator&#34;,
+        resource=&#34;_replicate&#34;,
         body=rm_nones_from_dict(
             {
-                &#34;_id&#34;: replication_id,
                 &#34;source&#34;: source,
                 &#34;target&#34;: target,
                 &#34;cancel&#34;: cancel,
@@ -6244,7 +6502,7 @@ that have not been written to disk.</p>
                 &#34;create_target&#34;: create_target,
                 &#34;create_target_params&#34;: create_target_params,
                 &#34;doc_ids&#34;: doc_ids,
-                &#34;filter_func&#34;: filter_func,
+                &#34;filter&#34;: filter_func,
                 &#34;selector&#34;: selector,
                 &#34;source_proxy&#34;: source_proxy,
                 &#34;target_proxy&#34;: target_proxy,
@@ -6277,7 +6535,8 @@ additional parameters like headers. Eg:</p>
 </code></pre>
 </dd>
 <dt><strong><code>replication_id</code></strong> :&ensp;<code>str</code></dt>
-<dd>The ID of the replication document.</dd>
+<dd>Deprecated. Ignored for one-shot replication (the <code>_replicate</code> endpoint does not accept
+a replication document ID).</dd>
 <dt><strong><code>cancel</code></strong> :&ensp;<code>bool</code></dt>
 <dd>Cancels the replication.</dd>
 <dt><strong><code>continuous</code></strong> :&ensp;<code>bool</code></dt>
@@ -6699,6 +6958,8 @@ remote node's port (<code>add_node</code>).</dd>
 <li><code><a title="couchdb3.sync.Database.create" href="#couchdb3.sync.Database.create">create</a></code></li>
 <li><code><a title="couchdb3.sync.Database.delete" href="#couchdb3.sync.Database.delete">delete</a></code></li>
 <li><code><a title="couchdb3.sync.Database.delete_attachment" href="#couchdb3.sync.Database.delete_attachment">delete_attachment</a></code></li>
+<li><code><a title="couchdb3.sync.Database.delete_index" href="#couchdb3.sync.Database.delete_index">delete_index</a></code></li>
+<li><code><a title="couchdb3.sync.Database.design_docs" href="#couchdb3.sync.Database.design_docs">design_docs</a></code></li>
 <li><code><a title="couchdb3.sync.Database.explain" href="#couchdb3.sync.Database.explain">explain</a></code></li>
 <li><code><a title="couchdb3.sync.Database.find" href="#couchdb3.sync.Database.find">find</a></code></li>
 <li><code><a title="couchdb3.sync.Database.get" href="#couchdb3.sync.Database.get">get</a></code></li>
@@ -6720,6 +6981,7 @@ remote node's port (<code>add_node</code>).</dd>
 <li>
 <h4><code><a title="couchdb3.sync.Partition" href="#couchdb3.sync.Partition">Partition</a></code></h4>
 <ul class="">
+<li><code><a title="couchdb3.sync.Partition.add_partition_to_bulk_get_doc" href="#couchdb3.sync.Partition.add_partition_to_bulk_get_doc">add_partition_to_bulk_get_doc</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.add_partition_to_doc" href="#couchdb3.sync.Partition.add_partition_to_doc">add_partition_to_doc</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.add_partition_to_str" href="#couchdb3.sync.Partition.add_partition_to_str">add_partition_to_str</a></code></li>
 <li><code><a title="couchdb3.sync.Partition.all_docs" href="#couchdb3.sync.Partition.all_docs">all_docs</a></code></li>

--- a/docs/sync/server.html
+++ b/docs/sync/server.html
@@ -113,11 +113,11 @@ el.replaceWith(d);
 
     def __repr__(self) -&gt; str:
         &#34;&#34;&#34;
-        Close the session on delete.
+        Basic repr.
 
         Returns
         -------
-        str
+        str : The instance&#39;s representation.
         &#34;&#34;&#34;
         return f&#34;{super().__repr__()}: {self.url}&#34;
 
@@ -410,7 +410,8 @@ el.replaceWith(d);
                 {“url”:”url in here”, “headers”: {“header1”:”value1”, …}}
 
         replication_id : str
-            The ID of the replication document.
+            Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+            a replication document ID).
         cancel : bool
             Cancels the replication.
         continuous : bool
@@ -456,10 +457,9 @@ el.replaceWith(d);
                 &#39;Arguments &#34;doc_ids&#34;, &#34;filter_func&#34; and &#34;selector&#34; are mutually exclusive.&#39;
             )
         return self._post(
-            resource=&#34;_replicator&#34;,
+            resource=&#34;_replicate&#34;,
             body=rm_nones_from_dict(
                 {
-                    &#34;_id&#34;: replication_id,
                     &#34;source&#34;: source,
                     &#34;target&#34;: target,
                     &#34;cancel&#34;: cancel,
@@ -467,7 +467,7 @@ el.replaceWith(d);
                     &#34;create_target&#34;: create_target,
                     &#34;create_target_params&#34;: create_target_params,
                     &#34;doc_ids&#34;: doc_ids,
-                    &#34;filter_func&#34;: filter_func,
+                    &#34;filter&#34;: filter_func,
                     &#34;selector&#34;: selector,
                     &#34;source_proxy&#34;: source_proxy,
                     &#34;target_proxy&#34;: target_proxy,
@@ -1450,7 +1450,8 @@ that have not been written to disk.</p>
             {“url”:”url in here”, “headers”: {“header1”:”value1”, …}}
 
     replication_id : str
-        The ID of the replication document.
+        Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+        a replication document ID).
     cancel : bool
         Cancels the replication.
     continuous : bool
@@ -1496,10 +1497,9 @@ that have not been written to disk.</p>
             &#39;Arguments &#34;doc_ids&#34;, &#34;filter_func&#34; and &#34;selector&#34; are mutually exclusive.&#39;
         )
     return self._post(
-        resource=&#34;_replicator&#34;,
+        resource=&#34;_replicate&#34;,
         body=rm_nones_from_dict(
             {
-                &#34;_id&#34;: replication_id,
                 &#34;source&#34;: source,
                 &#34;target&#34;: target,
                 &#34;cancel&#34;: cancel,
@@ -1507,7 +1507,7 @@ that have not been written to disk.</p>
                 &#34;create_target&#34;: create_target,
                 &#34;create_target_params&#34;: create_target_params,
                 &#34;doc_ids&#34;: doc_ids,
-                &#34;filter_func&#34;: filter_func,
+                &#34;filter&#34;: filter_func,
                 &#34;selector&#34;: selector,
                 &#34;source_proxy&#34;: source_proxy,
                 &#34;target_proxy&#34;: target_proxy,
@@ -1540,7 +1540,8 @@ additional parameters like headers. Eg:</p>
 </code></pre>
 </dd>
 <dt><strong><code>replication_id</code></strong> :&ensp;<code>str</code></dt>
-<dd>The ID of the replication document.</dd>
+<dd>Deprecated. Ignored for one-shot replication (the <code>_replicate</code> endpoint does not accept
+a replication document ID).</dd>
 <dt><strong><code>cancel</code></strong> :&ensp;<code>bool</code></dt>
 <dd>Cancels the replication.</dd>
 <dt><strong><code>continuous</code></strong> :&ensp;<code>bool</code></dt>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "couchdb3"
-version = "3.3.1"
+version = "3.4.0"
 description = "A wrapper around the CouchDB API."
 authors = [{ name = "Nikolai Vlahovic", email = "vlahovic.REDACTED_USERlai@gmail.com" }]
 requires-python = ">= 3.11"

--- a/scripts/html.sh
+++ b/scripts/html.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 uv pip install pdoc3 --quiet
 rm -rf docs
-uv run pdoc --html -o docs src/couchdb3 --force
+uv run pdoc3 --html -o docs src/couchdb3 --force
 mv docs/couchdb3/* docs/
 rm -rf docs/couchdb3
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="CouchDB3",
-    version="3.3.1",
+    version="3.4.0",
     author="Nikolai Vlahovic",
     author_email="REDACTED_USERlai@nexup.com",
     description="A wrapper around the CouchDB API.",

--- a/src/couchdb3/aio/async_base.py
+++ b/src/couchdb3/aio/async_base.py
@@ -162,10 +162,10 @@ class AsyncBase:
         bool : `True` if the auth token is expired or absent.
         """
         try:
-            return (
-                next(_.expires for _ in self.session.cookies.jar if _.name == "AuthSession")
-                <= datetime.now(UTC).timestamp()
-            )
+            expires = next(_.expires for _ in self.session.cookies.jar if _.name == "AuthSession")
+            if expires is None:
+                return False
+            return expires <= datetime.now(UTC).timestamp()
         except StopIteration:
             return True
 

--- a/src/couchdb3/aio/async_database.py
+++ b/src/couchdb3/aio/async_database.py
@@ -160,6 +160,72 @@ class AsyncDatabase(AsyncBase):
             **kwargs,
         )
 
+    async def design_docs(
+        self,
+        *,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        endkey: str | None = None,
+        include_docs: bool | None = None,
+        keys: Iterable[str] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+        startkey: str | None = None,
+        update_seq: bool | None = None,
+    ) -> ViewResult:
+        """
+        Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+        This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+        Parameters
+        ----------
+        conflicts : bool
+            Include conflicts information. Ignored if `include_docs` isn't `True`. Default is `None`.
+        descending : bool
+            Return the documents in descending order by key. Default is `None`.
+        endkey : str
+            Stop returning records when the specified key is reached. Default is `None`.
+        include_docs : bool
+            Include the associated document with each row. Default is `None`.
+        keys : Iterable[str]
+            Return only documents where the key matches one of the keys specified in the argument.
+            Default is `None`.
+        limit : int
+            Limit the number of the returned documents. Default is `None`.
+        skip : int
+            Skip this number of records before starting to return the results. Default is `None`.
+        startkey : str
+            Return records starting with the specified key. Default is `None`.
+        update_seq : bool
+            Whether to include an `update_seq` value indicating the sequence id of the database.
+            Default is `None`.
+
+        Returns
+        -------
+        ViewResult
+        """
+        return ViewResult(
+            **(
+                await self._get(
+                    resource="_design_docs",
+                    query_kwargs=rm_nones_from_dict(
+                        {
+                            "conflicts": conflicts,
+                            "descending": descending,
+                            "endkey": endkey,
+                            "include_docs": include_docs,
+                            "keys": keys,
+                            "limit": limit,
+                            "skip": skip,
+                            "startkey": startkey,
+                            "update_seq": update_seq,
+                        }
+                    ),
+                )
+            ).json()
+        )
+
     async def bulk_docs(
         self,
         docs: list[dict | Document],
@@ -757,7 +823,7 @@ class AsyncDatabase(AsyncBase):
         tuple[str, bool, str] : (id, ok, rev)
         """
         if partitioned:
-            options = (options or {}).update({"partitioned": partitioned})
+            options = {**(options or {}), "partitioned": partitioned}
         return await self.save(
             doc=rm_nones_from_dict(
                 {
@@ -857,6 +923,28 @@ class AsyncDatabase(AsyncBase):
             )
         ).json()
         return data["result"], data["id"], data["name"]
+
+    async def delete_index(self, ddoc: str, name: str, index_type: str = "json") -> bool:
+        """
+        Delete an index from a database. For more info, please refer to
+        [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+        Parameters
+        ----------
+        ddoc : str
+            Name of the design document the index belongs to. A `_design/` prefix is stripped
+            automatically.
+        name : str
+            Name of the index.
+        index_type : str
+            Can be `json` or `text`. Defaults to `json`.
+
+        Returns
+        -------
+        bool : `True` upon successful deletion.
+        """
+        ddoc = ddoc.removeprefix("_design/")
+        return (await self._delete(resource=f"_index/{ddoc}/{index_type}/{name}")).json().get("ok")
 
     async def security(self) -> SecurityDocument:
         """
@@ -1386,7 +1474,7 @@ class AsyncPartition(AsyncDatabase):
     async def bulk_get(self, docs: list[dict | Document], revs: bool = False) -> list[dict]:
         """See `AsyncDatabase.bulk_get`. Prepends partition ID to document IDs."""
         return await super().bulk_get(
-            docs=[self.add_partition_to_doc(doc) for doc in docs],
+            docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
             revs=revs,
         )
 
@@ -1522,7 +1610,7 @@ class AsyncPartition(AsyncDatabase):
 
     def add_partition_to_str(self, string: str) -> str:
         """Append the instance's partition ID to a string if not already present."""
-        if string.startswith(self.partition_id):
+        if string.startswith(f"{self.partition_id}:"):
             return string
         return f"{self.partition_id}:{string}"
 
@@ -1532,4 +1620,12 @@ class AsyncPartition(AsyncDatabase):
         if docid is None:
             return doc
         doc["_id"] = self.add_partition_to_str(docid)
+        return doc
+
+    def add_partition_to_bulk_get_doc(self, doc: Document | dict) -> Document | dict:
+        """Append the instance's partition ID to a `bulk_get` document's `id` (or `_id`)."""
+        key = "_id" if "_id" in doc else "id" if "id" in doc else None
+        if key is None:
+            return doc
+        doc[key] = self.add_partition_to_str(doc[key])
         return doc

--- a/src/couchdb3/aio/async_server.py
+++ b/src/couchdb3/aio/async_server.py
@@ -333,6 +333,29 @@ class AsyncServer(AsyncBase):
         await self._delete(resource=resource)
         return True
 
+    async def has_db(self, name: str) -> bool:
+        """
+        Check if the server contains a database with the given name.
+
+        Note:
+        The async client cannot support the `name in server` syntax (Python does not allow
+        `__contains__` to be a coroutine). Use `await client.has_db(name)` instead.
+
+        Parameters
+        ----------
+        name : str
+            The database's name.
+
+        Returns
+        -------
+        bool : `True` if the database exists, otherwise `False`.
+        """
+        try:
+            await self._head(resource=name)
+            return True
+        except CouchDBError:
+            return False
+
     async def replicate(
         self,
         source: dict | str,
@@ -359,7 +382,8 @@ class AsyncServer(AsyncBase):
         target : dict | str
             Fully qualified target database URL or an object with URL and headers.
         replication_id : str
-            The ID of the replication document.
+            Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+            a replication document ID).
         cancel : bool
             Cancels the replication.
         continuous : bool
@@ -393,10 +417,9 @@ class AsyncServer(AsyncBase):
             )
         return (
             await self._post(
-                resource="_replicator",
+                resource="_replicate",
                 body=rm_nones_from_dict(
                     {
-                        "_id": replication_id,
                         "source": source,
                         "target": target,
                         "cancel": cancel,
@@ -404,7 +427,7 @@ class AsyncServer(AsyncBase):
                         "create_target": create_target,
                         "create_target_params": create_target_params,
                         "doc_ids": doc_ids,
-                        "filter_func": filter_func,
+                        "filter": filter_func,
                         "selector": selector,
                         "source_proxy": source_proxy,
                         "target_proxy": target_proxy,

--- a/src/couchdb3/sync/base.py
+++ b/src/couchdb3/sync/base.py
@@ -471,10 +471,10 @@ class Base:
         try:
             # httpx.Client.cookies.jar yields http.cookiejar.Cookie objects which
             # carry the .name and .expires attributes we need.
-            return (
-                next(_.expires for _ in self.session.cookies.jar if _.name == "AuthSession")
-                <= datetime.now(UTC).timestamp()
-            )
+            expires = next(_.expires for _ in self.session.cookies.jar if _.name == "AuthSession")
+            if expires is None:
+                return False
+            return expires <= datetime.now(UTC).timestamp()
         except StopIteration:
             return True
 

--- a/src/couchdb3/sync/database.py
+++ b/src/couchdb3/sync/database.py
@@ -162,6 +162,70 @@ class Database(Base):
             **kwargs,
         )
 
+    def design_docs(
+        self,
+        *,
+        conflicts: bool | None = None,
+        descending: bool | None = None,
+        endkey: str | None = None,
+        include_docs: bool | None = None,
+        keys: Iterable[str] | None = None,
+        limit: int | None = None,
+        skip: int | None = None,
+        startkey: str | None = None,
+        update_seq: bool | None = None,
+    ) -> ViewResult:
+        """
+        Executes the built-in `_design_docs` view, returning all the design documents in the database.
+
+        This is a shorthand for `_all_docs` filtered to the `_design/` key range.
+
+        Parameters
+        ----------
+        conflicts : bool
+            Include conflicts information. Ignored if `include_docs` isn't `True`. Default is `None`.
+        descending : bool
+            Return the documents in descending order by key. Default is `None`.
+        endkey : str
+            Stop returning records when the specified key is reached. Default is `None`.
+        include_docs : bool
+            Include the associated document with each row. Default is `None`.
+        keys : Iterable[str]
+            Return only documents where the key matches one of the keys specified in the argument.
+            Default is `None`.
+        limit : int
+            Limit the number of the returned documents. Default is `None`.
+        skip : int
+            Skip this number of records before starting to return the results. Default is `None`.
+        startkey : str
+            Return records starting with the specified key. Default is `None`.
+        update_seq : bool
+            Whether to include an `update_seq` value indicating the sequence id of the database.
+            Default is `None`.
+
+        Returns
+        -------
+        ViewResult
+        """
+        return ViewResult(
+            **self._get(
+                resource="_design_docs",
+                query_kwargs=rm_nones_from_dict(
+                    {
+                        "conflicts": conflicts,
+                        "descending": descending,
+                        "endkey": endkey,
+                        "include_docs": include_docs,
+                        "keys": keys,
+                        "limit": limit,
+                        "skip": skip,
+                        "startkey": startkey,
+                        "update_seq": update_seq,
+                    }
+                ),
+            ).json()
+        )
+
     def bulk_docs(self, docs: list[dict | Document], new_edits: bool = True) -> list[dict]:
         """
         The bulk document API allows you to create and update multiple documents at the same time within a single
@@ -848,7 +912,7 @@ class Database(Base):
         ... })
         """
         if partitioned:
-            options = (options or {}).update({"partitioned": partitioned})
+            options = {**(options or {}), "partitioned": partitioned}
         return self.save(
             doc=rm_nones_from_dict(
                 {
@@ -893,9 +957,6 @@ class Database(Base):
         Returns
         -------
         Tuple[str, bool, str] : The document's id ( `str`), the operation status (`bool`) and the revision ( `str`).
-        """
-        """
-        :return: 
         """
         batch = "ok" if batch else None
         data = self._put(
@@ -969,6 +1030,28 @@ class Database(Base):
             ),
         ).json()
         return data["result"], data["id"], data["name"]
+
+    def delete_index(self, ddoc: str, name: str, index_type: str = "json") -> bool:
+        """
+        Delete an index from a database. For more info, please refer to
+        [the official documentation](https://docs.couchdb.org/en/main/api/database/find.html#db-index).
+
+        Parameters
+        ----------
+        ddoc : str
+            Name of the design document the index belongs to. A `_design/` prefix is stripped
+            automatically.
+        name : str
+            Name of the index.
+        index_type : str
+            Can be `json` or `text`. Defaults to `json`.
+
+        Returns
+        -------
+        bool : `True` upon successful deletion.
+        """
+        ddoc = ddoc.removeprefix("_design/")
+        return self._delete(resource=f"_index/{ddoc}/{index_type}/{name}").json().get("ok")
 
     def security(self) -> SecurityDocument:
         """
@@ -1473,7 +1556,6 @@ class Partition(Database):
         ddoc: str,
         view: str | None = None,
         *,
-        # partition: str = None,
         conflicts: bool | None = None,
         descending: bool | None = None,
         endkey: Any | None = None,
@@ -1616,7 +1698,7 @@ class Partition(Database):
         Appends the partition's ID to the documents' ID.
         """
         return super().bulk_get(
-            docs=[self.add_partition_to_doc(doc) for doc in docs],
+            docs=[self.add_partition_to_bulk_get_doc(doc) for doc in docs],
             revs=revs,
         )
 
@@ -1816,7 +1898,7 @@ class Partition(Database):
         """
         Append the instance's partition ID to a string.
         """
-        if string.startswith(self.partition_id):
+        if string.startswith(f"{self.partition_id}:"):
             return string
         return f"{self.partition_id}:{string}"
 
@@ -1828,4 +1910,14 @@ class Partition(Database):
         if docid is None:
             return doc
         doc["_id"] = self.add_partition_to_str(docid)
+        return doc
+
+    def add_partition_to_bulk_get_doc(self, doc: Document | dict) -> Document | dict:
+        """
+        Append the instance's partition ID to a `bulk_get` document's `id` (or `_id`).
+        """
+        key = "_id" if "_id" in doc else "id" if "id" in doc else None
+        if key is None:
+            return doc
+        doc[key] = self.add_partition_to_str(doc[key])
         return doc

--- a/src/couchdb3/sync/server.py
+++ b/src/couchdb3/sync/server.py
@@ -81,11 +81,11 @@ class Server(Base):
 
     def __repr__(self) -> str:
         """
-        Close the session on delete.
+        Basic repr.
 
         Returns
         -------
-        str
+        str : The instance's representation.
         """
         return f"{super().__repr__()}: {self.url}"
 
@@ -378,7 +378,8 @@ class Server(Base):
                 {“url”:”url in here”, “headers”: {“header1”:”value1”, …}}
 
         replication_id : str
-            The ID of the replication document.
+            Deprecated. Ignored for one-shot replication (the `_replicate` endpoint does not accept
+            a replication document ID).
         cancel : bool
             Cancels the replication.
         continuous : bool
@@ -424,10 +425,9 @@ class Server(Base):
                 'Arguments "doc_ids", "filter_func" and "selector" are mutually exclusive.'
             )
         return self._post(
-            resource="_replicator",
+            resource="_replicate",
             body=rm_nones_from_dict(
                 {
-                    "_id": replication_id,
                     "source": source,
                     "target": target,
                     "cancel": cancel,
@@ -435,7 +435,7 @@ class Server(Base):
                     "create_target": create_target,
                     "create_target_params": create_target_params,
                     "doc_ids": doc_ids,
-                    "filter_func": filter_func,
+                    "filter": filter_func,
                     "selector": selector,
                     "source_proxy": source_proxy,
                     "target_proxy": target_proxy,

--- a/tests/test_async_database.py
+++ b/tests/test_async_database.py
@@ -82,6 +82,24 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         result = await self.db.compact()
         self.assertTrue(result)
 
+    async def test_compact_with_ddoc(self):
+        ddoc = "async-compact-design"
+        await self.db.put_design(
+            ddoc=ddoc,
+            rev=await self.db.rev(f"_design/{ddoc}"),
+            views={VIEW_ID: {"map": DOCUMENT_VIEW}},
+        )
+        self.assertTrue(await self.db.compact(ddoc=ddoc))
+
+    async def test_purge(self):
+        docid = "test-async-purge-doc"
+        await self.db.save({"_id": docid, "type": "async-purge-test"})
+        rev = await self.db.rev(docid)
+        result = await self.db.purge({docid: [rev]})
+        self.assertIsInstance(result, dict)
+        self.assertIn("purge_seq", result)
+        self.assertIsNone(await self.db.rev(docid))
+
     async def test_create(self):
         docid = "test-async-create"
         _id, ok, _rev = await self.db.create({"_id": docid, "type": "test"})
@@ -203,6 +221,28 @@ class TestAsyncDatabase(unittest.IsolatedAsyncioTestCase):
         self.assertIn(result, ["created", "exists"])
         self.assertIsInstance(_id, str)
         self.assertIsInstance(name, str)
+
+    async def test_delete_index(self):
+        await self.db.save_index(
+            index={"fields": ["name"]},
+            ddoc="async-delete-me-ddoc",
+            name="async-delete-me-idx",
+        )
+        self.assertTrue(
+            await self.db.delete_index(ddoc="async-delete-me-ddoc", name="async-delete-me-idx")
+        )
+
+    async def test_design_docs(self):
+        ddoc = "async-design-docs-ddoc"
+        await self.db.put_design(
+            ddoc=ddoc,
+            rev=await self.db.rev(f"_design/{ddoc}"),
+            views={VIEW_ID: {"map": DOCUMENT_VIEW}},
+        )
+        result = await self.db.design_docs()
+        self.assertIsInstance(result, ViewResult)
+        ids = [row.id for row in result.rows]
+        self.assertIn(f"_design/{ddoc}", ids)
 
     async def test_security(self):
         from couchdb3.document import SecurityDocument

--- a/tests/test_async_server.py
+++ b/tests/test_async_server.py
@@ -95,13 +95,13 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
     async def test_replicate_one_shot(self):
         if TEST_DB_NAME not in (await self.client.all_dbs()):
             await self.client.create(TEST_DB_NAME)
-        db = await self.client.get(TEST_DB_NAME)
-        target_db = f"{self.client.url}/{TEST_DB_NAME}-rep-once"
-        result = await self.client.replicate(
-            source=db.url,
-            target=target_db,
-            create_target=True,
-        )
+        source_db = await self.client.get(TEST_DB_NAME)
+        if not await source_db.rev("replicate-one-shot-doc"):
+            await source_db.save({"_id": "replicate-one-shot-doc", "type": "replicate"})
+        auth_header = {"Authorization": f"Basic {self.client.basic}"}
+        source = {"url": source_db.url, "headers": auth_header}
+        target = {"url": f"{self.client.url}/{TEST_DB_NAME}-rep-once", "headers": auth_header}
+        result = await self.client.replicate(source=source, target=target, create_target=True)
         self.assertTrue(result.get("ok"))
         self.assertIn("session_id", result)
 

--- a/tests/test_async_server.py
+++ b/tests/test_async_server.py
@@ -75,6 +75,10 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
                 db = await self.client.get(name)
                 self.assertIsInstance(db, AsyncDatabase)
 
+    async def test_has_db(self):
+        self.assertTrue(await self.client.has_db("_users"))
+        self.assertFalse(await self.client.has_db("definitely-not-a-real-db-12345"))
+
     async def test_replicate(self):
         if TEST_DB_NAME not in (await self.client.all_dbs()):
             await self.client.create(TEST_DB_NAME)
@@ -87,6 +91,19 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
             create_target=True,
         )
         self.assertTrue(result.get("ok"))
+
+    async def test_replicate_one_shot(self):
+        if TEST_DB_NAME not in (await self.client.all_dbs()):
+            await self.client.create(TEST_DB_NAME)
+        db = await self.client.get(TEST_DB_NAME)
+        target_db = f"{self.client.url}/{TEST_DB_NAME}-rep-once"
+        result = await self.client.replicate(
+            source=db.url,
+            target=target_db,
+            create_target=True,
+        )
+        self.assertTrue(result.get("ok"))
+        self.assertIn("session_id", result)
 
     async def test_rev(self):
         self.assertIsInstance(await self.client.rev("_users/_design/_auth"), str)
@@ -186,7 +203,7 @@ class TestAsyncClient(unittest.IsolatedAsyncioTestCase):
 @atexit.register
 def rm_test_dbs() -> None:
     """Remove temporary async test databases using the sync client."""
-    for dbname in [TEST_DB_NAME, f"{TEST_DB_NAME}-rep"]:
+    for dbname in [TEST_DB_NAME, f"{TEST_DB_NAME}-rep", f"{TEST_DB_NAME}-rep-once"]:
         if dbname in _SYNC_CLIENT:
             _SYNC_CLIENT.delete(dbname)
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -101,6 +101,24 @@ class TestDatabase(unittest.TestCase):
         DB.compact()
         self.assertTrue(DB.info().get("compact_running"))
 
+    def test_compact_with_ddoc(self):
+        ddoc = "compact-design"
+        DB.put_design(
+            ddoc=ddoc,
+            rev=DB.rev(f"_design/{ddoc}"),
+            views={VIEW_ID: {"map": DOCUMENT_VIEW}},
+        )
+        self.assertTrue(DB.compact(ddoc=ddoc))
+
+    def test_purge(self):
+        docid = "test-purge-doc"
+        DB.save({"_id": docid, "type": "purge-test"})
+        rev = DB.rev(docid)
+        result = DB.purge({docid: [rev]})
+        self.assertIsInstance(result, dict)
+        self.assertIn("purge_seq", result)
+        self.assertIsNone(DB.rev(docid))
+
     def test_copy(self):
         docid = "doc-id-test-copy"
         doc = {"_id": docid, "name": "Test Copy"}
@@ -336,6 +354,22 @@ class TestDatabase(unittest.TestCase):
         self.assertTrue(res in {"created", "exists"})
         self.assertEqual(_id, "_design/example-ddoc")
         self.assertEqual(name, "foo-index")
+
+    def test_delete_index(self):
+        DB.save_index(index={"fields": ["name"]}, ddoc="delete-me-ddoc", name="delete-me-idx")
+        self.assertTrue(DB.delete_index(ddoc="delete-me-ddoc", name="delete-me-idx"))
+
+    def test_design_docs(self):
+        ddoc = "design-docs-ddoc"
+        DB.put_design(
+            ddoc=ddoc,
+            rev=DB.rev(f"_design/{ddoc}"),
+            views={VIEW_ID: {"map": DOCUMENT_VIEW}},
+        )
+        result = DB.design_docs()
+        self.assertIsInstance(result, ViewResult)
+        ids = [row.id for row in result.rows]
+        self.assertIn(f"_design/{ddoc}", ids)
 
     def test_security(self):
         read_user = "reader-0"

--- a/tests/test_partitioned_database.py
+++ b/tests/test_partitioned_database.py
@@ -3,7 +3,9 @@
 import atexit
 import unittest
 
-from couchdb3.sync import Database, Server
+from couchdb3.document import Document
+from couchdb3.sync import Database, Partition, Server
+from couchdb3.view import ViewResult
 from tests.credentials import (
     COUCHDB0_URL,
     COUCHDB_PASSWORD,
@@ -16,6 +18,9 @@ DB_NAME: str = "tmp-test-partitioned-db"
 DB: Database = (
     CLIENT.get(DB_NAME) if DB_NAME in CLIENT else CLIENT.create(DB_NAME, partitioned=True)
 )
+
+PARTITION_ID: str = "partition-test"
+DDOC_ID: str = "partition-design"
 
 
 class TestPartitionedDatabase(unittest.TestCase):
@@ -43,6 +48,111 @@ class TestPartitionedDatabase(unittest.TestCase):
             self.assertEqual(_id, f"_design/{ddoc}")
             self.assertEqual(ok, True)
             self.assertIsInstance(_rev, str)
+
+    def test_put_design_partitioned_flag_persists(self):
+        ddoc = "document-design-flag"
+        DB.put_design(
+            ddoc=ddoc,
+            rev=DB.rev(f"_design/{ddoc}"),
+            views={"document-view": {"map": DOCUMENT_VIEW}},
+            partitioned=True,
+        )
+        saved = DB.get(f"_design/{ddoc}")
+        self.assertIsInstance(saved, Document)
+        self.assertEqual(saved["options"]["partitioned"], True)
+
+
+class TestPartition(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.partition: Partition = DB.get_partition(PARTITION_ID)
+
+    def test_type(self):
+        self.assertIsInstance(self.partition, Partition)
+
+    def test_save_and_get(self):
+        docid = "partition-save-doc"
+        _id, ok, _rev = self.partition.save(
+            {"_id": docid, "type": "document", "name": "partition-save"}
+        )
+        self.assertEqual(_id, f"{PARTITION_ID}:{docid}")
+        self.assertTrue(ok)
+        self.assertIsInstance(_rev, str)
+
+        doc = self.partition.get(docid)
+        self.assertIsInstance(doc, Document)
+        self.assertIn(PARTITION_ID, doc.id)
+
+    def test_get_returns_none_for_missing(self):
+        self.assertIsNone(self.partition.get("partition-missing-doc"))
+
+    def test_rev(self):
+        docid = "partition-rev-doc"
+        self.partition.save({"_id": docid, "type": "document"})
+        rev = self.partition.rev(docid)
+        self.assertIsInstance(rev, str)
+        self.assertTrue(rev.startswith("1-"))
+
+    def test_contains(self):
+        docid = "partition-contains-doc"
+        self.partition.save({"_id": docid, "type": "document"})
+        self.assertIn(docid, self.partition)
+        self.assertNotIn("partition-missing-doc", self.partition)
+
+    def test_delete(self):
+        docid = "partition-delete-doc"
+        self.partition.save({"_id": docid, "type": "document"})
+        self.assertTrue(self.partition.delete(docid=docid, rev=self.partition.rev(docid)))
+        self.assertNotIn(docid, self.partition)
+
+    def test_all_docs(self):
+        for i in range(3):
+            self.partition.save({"_id": f"partition-all-docs-{i}", "type": "document"})
+        result = self.partition.all_docs()
+        self.assertIsInstance(result, ViewResult)
+        ids = [row.id for row in result.rows]
+        for i in range(3):
+            self.assertIn(f"{PARTITION_ID}:partition-all-docs-{i}", ids)
+
+    def test_bulk_docs_and_bulk_get(self):
+        docs = [{"_id": f"partition-bulk-{i}", "type": "document"} for i in range(3)]
+        original_ids = [doc["_id"] for doc in docs]
+        results = self.partition.bulk_docs(docs)
+        self.assertEqual(len(results), 3)
+        for orig_id, res in zip(original_ids, results):
+            self.assertEqual(f"{PARTITION_ID}:{orig_id}", res["id"])
+            self.assertTrue(res["ok"])
+
+        fetched = self.partition.bulk_get(docs=[{"id": _id} for _id in original_ids])
+        self.assertEqual(len(fetched), 3)
+        for item in fetched:
+            self.assertIn("id", item)
+            self.assertIn("docs", item)
+            self.assertIn("ok", item["docs"][0])
+
+    def test_find(self):
+        self.partition.save({"_id": "partition-find-doc", "type": "partition-find"})
+        result = self.partition.find({"type": {"$eq": "partition-find"}})
+        self.assertIn("docs", result)
+        self.assertIsInstance(result["docs"], list)
+
+    def test_info(self):
+        info = self.partition.info()
+        self.assertIsInstance(info, dict)
+
+    def test_view(self):
+        ddoc = DDOC_ID
+        DB.put_design(
+            ddoc=ddoc,
+            rev=DB.rev(f"_design/{ddoc}"),
+            views={"document-view": {"map": DOCUMENT_VIEW}},
+            partitioned=True,
+        )
+        self.partition.save({"_id": "partition-view-doc", "type": "document"})
+        result = self.partition.view(ddoc, "document-view")
+        self.assertIsInstance(result, ViewResult)
+        ids = [row.id for row in result.rows]
+        self.assertIn(f"{PARTITION_ID}:partition-view-doc", ids)
 
 
 @atexit.register

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -75,12 +75,13 @@ class TestClient(unittest.TestCase):
     def test_replicate_one_shot(self):
         if TEST_DB_NAME not in CLIENT:
             CLIENT.create(TEST_DB_NAME)
-        target_db = f"{CLIENT.url}/{TEST_DB_NAME}-rep-once"
-        result = CLIENT.replicate(
-            source=CLIENT.get(TEST_DB_NAME).url,
-            target=target_db,
-            create_target=True,
-        )
+        source_db = CLIENT.get(TEST_DB_NAME)
+        if not source_db.rev("replicate-one-shot-doc"):
+            source_db.save({"_id": "replicate-one-shot-doc", "type": "replicate"})
+        auth_header = {"Authorization": f"Basic {CLIENT.basic}"}
+        source = {"url": source_db.url, "headers": auth_header}
+        target = {"url": f"{CLIENT.url}/{TEST_DB_NAME}-rep-once", "headers": auth_header}
+        result = CLIENT.replicate(source=source, target=target, create_target=True)
         self.assertTrue(result.get("ok"))
         self.assertIn("session_id", result)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,6 +72,18 @@ class TestClient(unittest.TestCase):
         )
         self.assertTrue(result.get("ok"))
 
+    def test_replicate_one_shot(self):
+        if TEST_DB_NAME not in CLIENT:
+            CLIENT.create(TEST_DB_NAME)
+        target_db = f"{CLIENT.url}/{TEST_DB_NAME}-rep-once"
+        result = CLIENT.replicate(
+            source=CLIENT.get(TEST_DB_NAME).url,
+            target=target_db,
+            create_target=True,
+        )
+        self.assertTrue(result.get("ok"))
+        self.assertIn("session_id", result)
+
     def test_rev(self):
         self.assertIsInstance(CLIENT.rev("_users/_design/_auth"), str)
         self.assertIs(CLIENT.rev("_users/test"), None)
@@ -166,13 +178,32 @@ class TestClient(unittest.TestCase):
         result = CLIENT.node_system()
         self.assertIsInstance(result, dict)
 
+    def test_cookie_auth_token_renewal(self):
+        with Server(
+            url=COUCHDB0_URL,
+            user=COUCHDB_USER,
+            password=COUCHDB_PASSWORD,
+            auth_method="cookie",
+        ) as client:
+            # No AuthSession cookie yet → token considered expired
+            self.assertTrue(client._is_auth_token_expired())
+            # A cookie-auth request triggers an automatic renewal
+            self.assertTrue(client.up())
+            self.assertFalse(client._is_auth_token_expired())
+            # Simulate expiry by dropping the cookie
+            client.session.cookies.clear()
+            self.assertTrue(client._is_auth_token_expired())
+            # Explicit renewal restores a valid token
+            client._renew_auth_token()
+            self.assertFalse(client._is_auth_token_expired())
+
 
 @atexit.register
 def rm_test_db() -> None:
     """
     Removing temporary test database.
     """
-    for dbname in [TEST_DB_NAME, f"{TEST_DB_NAME}-rep"]:
+    for dbname in [TEST_DB_NAME, f"{TEST_DB_NAME}-rep", f"{TEST_DB_NAME}-rep-once"]:
         if dbname in CLIENT:
             CLIENT.delete(dbname)
 

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "couchdb3"
-version = "3.3.1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bumps to **v3.4.0** with correctness fixes, new API surface, and broader test coverage across both the sync and async clients.

## Bug fixes (sync + async)

- **`put_design`** — `options = (options or {}).update(...)` always produced `None`, silently dropping caller-supplied options. Now merges correctly.
- **`Server.replicate`** — was posting to the `_replicator` database; now posts to the one-shot `/_replicate` endpoint, dropping the invalid `_id` field and mapping `filter_func` → `filter` in the body.
- **`Server.__repr__`** — fixed copy-pasted docstring ("Close the session on delete").
- **`Database.save`** — removed orphaned `:return:` stub.
- **`Partition.add_partition_to_str`** — tightened prefix guard to `partition_id + ":"` so IDs that merely share a prefix aren't wrongly skipped.
- **`Partition.bulk_get`** — now prefixes the `id` key (via new `add_partition_to_bulk_get_doc`) instead of silently looking only at `_id`.
- **`_is_auth_token_expired`** — returns `False` for session cookies with no expiry instead of raising `TypeError`.

## New API (sync + async)

- `Database.delete_index(ddoc, name, index_type="json")` — `DELETE /{db}/_index/{ddoc}/{type}/{name}` (strips a `_design/` prefix).
- `Database.design_docs(...)` — `GET /{db}/_design_docs` with an explicit signature.
- `AsyncServer.has_db(name)` — async existence check mirroring the sync `name in server`.

## Tests

- Full sync `Partition` method coverage (`TestPartition`).
- `test_delete_index`, `test_design_docs`, `test_compact_with_ddoc`, `test_purge`.
- `test_cookie_auth_token_renewal`, `test_has_db`, `test_replicate_one_shot`.
- `test_replicate_one_shot` uses credentialed source/target URLs (one-shot replication requires authenticated URLs and a non-empty source).

## Bookkeeping

- Version `3.3.1` → `3.4.0`.
- Updated `TODO.md`, the `couchdb3-api-coverage` skill tracker, and the README `has_db` note.
- Regenerated API docs (`make html`), and fixed `scripts/html.sh` to invoke `pdoc3`.

## Verification

- `uv run ruff check .` — clean
- `uv run ruff format .` — clean
- `make test` — 150 tests pass (2 skipped), against live CouchDB 3.3.3
- `make build` — `couchdb3-3.4.0` wheel + sdist built